### PR TITLE
Add v3 polling & authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,6 +704,7 @@ For instance:
 - **Fuel Data Availability:** The [`sensor.<make_model>_fuel`](#sensormake_model_fuel) (amount in litres) is frequently `null` for many vehicles. However, [`sensor.<make_model>_fuel_percent`](#sensormake_model_fuel_percent) and [`sensor.<make_model>_fuel_range`](#sensormake_model_fuel_range) are typically more reliable and provide comprehensive fuel monitoring even when the amount is unavailable.
 - **API Latency:** There can be significant delays (seconds to minutes) between sending a command (e.g., start charging) and the vehicle executing/reporting the change back through the API. The state in Home Assistant will update after the next successful data poll.
 - **Rate Limits:** Be mindful of the 500 calls/vehicle/month limit on the free tier.
+- **Single User:** Smartcar applications must be configured with only a single user connected to vehicles.
 - **FAQ:** In case ou haven't found the [FAQ](FAQ.md) yet, it is a great resource for troubleshooting and discovering if you're running up against an issue with this integration vs. a limitation in Smartcar's platform.
 
 ## Support / Issues

--- a/README.md
+++ b/README.md
@@ -69,12 +69,14 @@ Initially, you will have the option to enable [webhooks](#webhooks). If desired,
 
 #### Authorization Data Entry
 
-1. Choose a name for your credentials and enter the **Client ID** and **Client Secret** which can be found in the [Smartcar dashboard][smartcar-dashboard].
+1. Choose a name for your credentials and enter the **Client ID** and **Client Secret** which can be found in the [Smartcar dashboard][smartcar-dashboard] under _Configuration_ &rarr; _API credentials_.
 1. **Crucially, set the "Redirect URIs"** in the Smartcar settings for your application. You need to add **exactly** the URI your Home Assistant instance uses for OAuth callbacks.
    - Most users will simply use the **My Home Assistant** URI: `https://my.home-assistant.io/redirect/oauth`
      > Note: This is not a placeholder. It is the URI that must be used unless you’ve disabled or removed the `default_config:` line from your configuration and disabled the [My Home Assistant Integration](https://www.home-assistant.io/integrations/my/).
    - Add **only** the correct URI for your setup.
 1. Continue to the next step.
+1. Enter your _Application ID_ which can be found in the [Smartcar dashboard][smartcar-dashboard] under _Configuration_ &rarr; _Application details_.
+1. If you plan to use webhooks, also enter your _Application management token_ which can be found in the [Smartcar dashboard][smartcar-dashboard] under _Configuration_ &rarr; _API credentials_.
 1. Select the **Permissions** you want Home Assistant to be able to access. To enable all entities in this integration, select all relevant permissions:
    - Get total distance traveled
    - Get the vehicle's location
@@ -698,6 +700,19 @@ For instance:
 - `homeassistant.update_entity` on [`sensor.<make_model>_battery`](#sensormake_model_battery) and [`sensor.<make_model>_range`](#sensormake_model_range) will make a single batch request that counts as **one** API call because the entities are related.
 - `homeassistant.update_entity` on [`sensor.<make_model>_battery`](#sensormake_model_battery) and [`sensor.<make_model>_odometer`](#sensormake_model_odometer) will make a single batch request that counts as **two** API calls since they are unrelated.
 
+## Upgrading from Legacy `v2` API to `v3`
+
+For now, you can continue to use the `v2` API as long as it is supported by Smartcar, but [Smartcar documents the deprecation thusly](https://smartcar.com/docs/getting-started/how-to/m2m/migration-guide#overview):
+
+> The Vehicles API v2.0 will be deprecated by Q4 of 2026. We recommend migrating to the latest version as soon as possible to ensure continued support and access to new features.
+
+To upgrade from `v2` to `v3`, you need to use the _API credentials_ rather than the _Legacy credentials_. In Home Assistant, you will need to:
+
+- Remove all Smartcar integrations that use v2. _Note: this is required in order to remove credentials in the next step_.  
+  Before removing the items, you may want to note any customizations to entities such as entity IDs or areas in which entities are located so that you can re-create them once the migration is complete.
+- Remove all [_Application Credentials_][ha-application-credentials] that use a v2 `client_id`. To be safe, you can remove all Smartcar credentials from the _Application Credentials_.
+- Re-setup each smart car integration, ensuring that you use the new v3 _API credentials_ and _Application ID_ rather than _Legacy Credentials_.
+
 ## Known Issues / Limitations
 
 - **Vehicle Compatibility:** Not all features are supported by all vehicle makes/models/years via the Smartcar API. Entities for unsupported features (e.g., [fuel status](#sensormake_model_fuel) for EVs or [lock control](#lockmake_model_door_lock) for VW ID.4 2023+) may or may still be created, but not function. Check the Smartcar compatibility details for your specific vehicle.
@@ -719,4 +734,5 @@ Please report any issues you find with this integration by opening an issue on t
 [config-flow-start]: https://my.home-assistant.io/redirect/config_flow_start/?domain=smartcar
 [smartcar-dashboard]: https://dashboard.smartcar.com/team/applications
 [ha-remote-access]: https://www.home-assistant.io/docs/configuration/remote/
+[ha-application-credentials]: https://www.home-assistant.io/integrations/application_credentials/
 [gh-sponsors]: https://github.com/sponsors/wbyoung

--- a/custom_components/smartcar/__init__.py
+++ b/custom_components/smartcar/__init__.py
@@ -22,11 +22,17 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from . import util
 from .auth import AbstractAuth
 from .auth_impl import AccessTokenAuthImpl, AsyncConfigEntryAuth
-from .const import API_HOST, CONF_CLOUDHOOK, DOMAIN, PLATFORMS, Scope
+from .const import API_ENDPOINTS, CONF_CLOUDHOOK, DOMAIN, PLATFORMS, Scope
 from .coordinator import SmartcarVehicleCoordinator
-from .errors import EmptyVehicleListError, InvalidAuthError, MissingVINError
+from .errors import (
+    EmptyVehicleListError,
+    InvalidAuthError,
+    MissingVINError,
+    UnsupportedUserConfigurationError,
+)
 from .services import async_setup_services
 from .types import SmartcarData
+from .util import api_version_for_client_id
 from .webhooks import handle_webhook, webhook_url_from_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -58,7 +64,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     implementation = await async_get_config_entry_implementation(hass, entry)
     websession = async_get_clientsession(hass)
     oauth_session = OAuth2Session(hass, entry, implementation)
-    auth = AsyncConfigEntryAuth(websession, oauth_session, API_HOST)
+    auth = AsyncConfigEntryAuth(
+        websession,
+        implementation,
+        oauth_session,
+        API_ENDPOINTS,
+        user_id=entry.data.get("user_id"),
+    )
     coordinators: dict[str, SmartcarVehicleCoordinator] = {}
     meta_coordinator = DataUpdateCoordinator(
         hass, _LOGGER, name=f"{DOMAIN}_meta", config_entry=entry
@@ -197,11 +209,17 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 
     if config_entry.version == 1:
         old_data = config_entry.data
+        implementation = await async_get_config_entry_implementation(hass, config_entry)
         session = async_get_clientsession(hass)
         token = old_data[CONF_TOKEN]
         access_token = token[CONF_ACCESS_TOKEN]
         scopes = token["scope"].split(" ")
-        auth = AccessTokenAuthImpl(session, access_token, API_HOST)
+        auth = AccessTokenAuthImpl(
+            session,
+            access_token,
+            API_ENDPOINTS,
+            version=api_version_for_client_id(implementation.client_id),
+        )
 
         # copy old data & remove old keys
         new_data = {**old_data}
@@ -286,6 +304,7 @@ async def _store_all_vehicles(
 
     Raises:
         EmptyVehicleListError: If no vehicles are found.
+        UnsupportedUserConfigurationError: If there is not exactly 1 user.
         InvalidAuthError: If the request cannot be authorized.
         ClientResponseError: If there is a request error.
     """
@@ -295,13 +314,41 @@ async def _store_all_vehicles(
     data["vehicles"] = {}
 
     try:
-        vehicle_list_resp = await auth.request(
-            "get",
-            "vehicles",
-        )
-        vehicle_list_resp.raise_for_status()
-        vehicle_list_data = await vehicle_list_resp.json()
-        vehicle_ids = vehicle_list_data.get("vehicles", [])
+        if auth.version == "v2":
+            vehicle_list_resp = await auth.request_v2("get", "vehicles")
+            vehicle_list_resp.raise_for_status()
+            vehicle_list_data = await vehicle_list_resp.json()
+            vehicle_ids = vehicle_list_data.get("vehicles", [])
+        if auth.version == "v3":
+            connections_list_resp = await auth.request_v3("get", "connections")
+            connections_list_resp.raise_for_status()
+            connections_list_data = await connections_list_resp.json()
+            vehicle_ids = [
+                vehicle_id
+                for connection in connections_list_data.get("data", [])
+                if (
+                    vehicle_id := connection.get("relationships", {})
+                    .get("vehicle", {})
+                    .get("data", {})
+                    .get("id", None)
+                )
+            ]
+            user_ids = {
+                user_id
+                for connection in connections_list_data.get("data", [])
+                if (
+                    user_id := connection.get("relationships", {})
+                    .get("user", {})
+                    .get("data", {})
+                    .get("id", None)
+                )
+            }
+
+            if len(user_ids) != 1:
+                raise UnsupportedUserConfigurationError
+
+            auth.user_id = data["user_id"] = next(iter(user_ids))
+
     except ClientResponseError as err:
         if err.status == HTTPStatus.UNAUTHORIZED:
             msg = f"Auth error fetching vehicle list: {err.status}"
@@ -333,13 +380,30 @@ async def _store_vehicle_details(
 
     try:
         _LOGGER.debug("Fetching VIN for vehicle ID: %s", vehicle_id)
-        vin_resp = await auth.request(
-            "get",
-            f"vehicles/{vehicle_id}/vin",
-        )
-        vin_resp.raise_for_status()
-        vin_data = await vin_resp.json()
-        vin = vin_data.get("vin")
+        if auth.version == "v2":
+            vin_resp = await auth.request_v2("get", f"vehicles/{vehicle_id}/vin")
+            vin_resp.raise_for_status()
+            vin_data = await vin_resp.json()
+            vin = vin_data.get("vin")
+        if auth.version == "v3":
+            signals_resp = await auth.request_v3(
+                "get",
+                f"vehicles/{vehicle_id}/signals/vehicleidentification-vin",
+            )
+            signals_resp.raise_for_status()
+            signals_data = await signals_resp.json()
+            vehicle_info = (
+                signals_data.get("included", {})
+                .get("vehicle", {})
+                .get("attributes", {})
+            )
+
+            vin = (
+                signals_data.get("data", {})
+                .get("attributes", {})
+                .get("body", {})
+                .get("value", None)
+            )
 
         if not vin:
             msg = f"No VIN for vehicle {vehicle_id}"
@@ -349,16 +413,15 @@ async def _store_vehicle_details(
             "vin": vin,
         }
 
-        _LOGGER.debug("Fetching attributes for vehicle ID: %s", vehicle_id)
-        attr_resp = await auth.request(
-            "get",
-            f"vehicles/{vehicle_id}",
-        )
-        attr_resp.raise_for_status()
-        vehicle_info = await attr_resp.json()
+        if auth.version == "v2":
+            _LOGGER.debug("Fetching attributes for vehicle ID: %s", vehicle_id)
+            attr_resp = await auth.request_v2("get", f"vehicles/{vehicle_id}")
+            attr_resp.raise_for_status()
+            vehicle_info = await attr_resp.json()
+
         make = vehicle_info.get("make")
         model = vehicle_info.get("model")
-        year = vehicle_info.get("year")
+        year = str(vehicle_info.get("year"))
 
         data["vehicles"][vehicle_id].update(
             {

--- a/custom_components/smartcar/__init__.py
+++ b/custom_components/smartcar/__init__.py
@@ -28,7 +28,6 @@ from .coordinator import SmartcarVehicleCoordinator
 from .errors import (
     EmptyVehicleListError,
     InvalidAuthError,
-    MissingVINError,
     UnsupportedUserConfigurationError,
 )
 from .services import async_setup_services
@@ -63,6 +62,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ConfigEntryError: For overlapping VIN in config entries.
     """
     implementation = await async_get_config_entry_implementation(hass, entry)
+    version = api_version_for_client_id(implementation.client_id)
     websession = async_get_clientsession(hass)
     oauth_session = OAuth2Session(hass, entry, implementation)
     auth = AsyncConfigEntryAuth(
@@ -86,29 +86,46 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     other_vins = vehicle_vins_in_use(hass, entry)
 
     for vehicle_id, details in entry.data.get("vehicles", {}).items():
-        vin = details["vin"]
+        vin = details.get("vin")
         make = details.get("make")
         model = details.get("model")
         year = details.get("year")
 
-        if vin in other_vins:
+        if vin is not None and vin in other_vins:
             msg = f"Cannot setup multiple config entries with VIN {vin}"
             raise ConfigEntryError(msg)
+
+        device_id = vehicle_id
+
+        if version == "v2" and vin:
+            device_id = vin
 
         # register device
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
-            identifiers={(DOMAIN, vin)},
+            identifiers={(DOMAIN, device_id)},
             manufacturer=make,
             model=f"{model} ({year})" if model and year else model,
-            name=f"{make} {model}" if make and model else f"Smartcar {vin[-4:]}",
+            name=f"{make} {model}"
+            if make and model
+            else f"Smartcar {(vin or vehicle_id)[-4:]}",
         )
-        _LOGGER.info("Registered device for VIN: %s", vin)
+        _LOGGER.info("Registered device for %s (VIN: %s)", vehicle_id, vin)
 
         # create and store coordinator
-        coordinator = SmartcarVehicleCoordinator(hass, auth, vehicle_id, vin, entry)
-        coordinators[vin] = coordinator
-        _LOGGER.debug("Coordinator created and initial data fetched for VIN: %s", vin)
+        coordinators[vehicle_id] = SmartcarVehicleCoordinator(
+            hass,
+            auth=auth,
+            vehicle_id=vehicle_id,
+            vin=vin,
+            entry=entry,
+            version=version,
+        )
+        _LOGGER.debug(
+            "Coordinator created and initial data fetched for %s (VIN: %s)",
+            vehicle_id,
+            vin,
+        )
 
     # setup platforms before doing first refresh. this gets the entity registry
     # populated with the desired entities & allows the coordinator to determine
@@ -168,7 +185,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_do_first_refresh(coordinator: SmartcarVehicleCoordinator) -> None:
     await coordinator.async_config_entry_first_refresh()
     _LOGGER.debug(
-        "Coordinator created and initial data fetched for VIN: %s", coordinator.vin
+        "Coordinator created and initial data fetched for %s (VIN: %s)",
+        coordinator.vehicle_id,
+        coordinator.vin,
     )
 
 
@@ -292,7 +311,8 @@ def vehicle_vins_in_use(
         vehicle["vin"]
         for other_entry in hass.config_entries.async_entries(DOMAIN)
         for vehicle in other_entry.data.get("vehicles", {}).values()
-        if not config_entry or other_entry.unique_id != config_entry.unique_id
+        if vehicle.get("vin")
+        and (not config_entry or other_entry.unique_id != config_entry.unique_id)
     }
 
 
@@ -390,7 +410,6 @@ async def _store_vehicle_details(
     """Fetch and store data for a single vehicle.
 
     Raises:
-        MissingVINError: If the VIN is not available.
         InvalidAuthError: If the request cannot be authorized.
         ClientResponseError: If there is a request error.
     """
@@ -423,14 +442,6 @@ async def _store_vehicle_details(
                 .get("value", None)
             )
 
-        if not vin:
-            msg = f"No VIN for vehicle {vehicle_id}"
-            raise MissingVINError(msg)
-
-        data["vehicles"][vehicle_id] = {
-            "vin": vin,
-        }
-
         if auth.version == "v2":
             _LOGGER.debug("Fetching attributes for vehicle ID: %s", vehicle_id)
             attr_resp = await auth.request_v2("get", f"vehicles/{vehicle_id}")
@@ -441,13 +452,15 @@ async def _store_vehicle_details(
         model = vehicle_info.get("model")
         year = str(vehicle_info.get("year"))
 
-        data["vehicles"][vehicle_id].update(
-            {
-                "make": make,
-                "model": model,
-                "year": year,
-            }
-        )
+        data["vehicles"][vehicle_id] = {
+            "make": make,
+            "model": model,
+            "year": year,
+        }
+
+        if vin:
+            data["vehicles"][vehicle_id]["vin"] = vin
+
     except ClientResponseError as err:
         if err.status == HTTPStatus.UNAUTHORIZED:
             msg = f"Auth error [{err.status}] during vehicle setup"

--- a/custom_components/smartcar/__init__.py
+++ b/custom_components/smartcar/__init__.py
@@ -319,7 +319,8 @@ async def _store_all_vehicles(
             vehicle_list_resp.raise_for_status()
             vehicle_list_data = await vehicle_list_resp.json()
             vehicle_ids = vehicle_list_data.get("vehicles", [])
-        if auth.version == "v3":
+        else:
+            assert auth.version == "v3"
             connections_list_resp = await auth.request_v3("get", "connections")
             connections_list_resp.raise_for_status()
             connections_list_data = await connections_list_resp.json()
@@ -385,7 +386,8 @@ async def _store_vehicle_details(
             vin_resp.raise_for_status()
             vin_data = await vin_resp.json()
             vin = vin_data.get("vin")
-        if auth.version == "v3":
+        else:
+            assert auth.version == "v3"
             signals_resp = await auth.request_v3(
                 "get",
                 f"vehicles/{vehicle_id}/signals/vehicleidentification-vin",

--- a/custom_components/smartcar/__init__.py
+++ b/custom_components/smartcar/__init__.py
@@ -381,6 +381,12 @@ async def _store_all_vehicles(
                 )
             }
 
+            # check for an empty vehicle list first: with no connections at
+            # all, the user count check below would misreport the problem as
+            # a multi-user configuration issue.
+            if not vehicle_ids:
+                raise EmptyVehicleListError
+
             if len(user_ids) != 1:
                 raise UnsupportedUserConfigurationError
 

--- a/custom_components/smartcar/__init__.py
+++ b/custom_components/smartcar/__init__.py
@@ -143,6 +143,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             translation_key="legacy_client_id",
             translation_placeholders={
                 "title": entry.title,
+                "docs_url": "https://github.com/wbyoung/smartcar#upgrading-from-legacy-v2-api-to-v3",
             },
         )
 

--- a/custom_components/smartcar/__init__.py
+++ b/custom_components/smartcar/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
     OAuth2Session,
     async_get_config_entry_implementation,
 )
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -130,6 +131,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     else:
         _LOGGER.debug("Webhooks are not enabled")
+
+    if auth.version == "v2":
+        async_create_issue(
+            hass,
+            DOMAIN,
+            f"legacy_client_id_{entry.entry_id}",
+            is_fixable=True,
+            is_persistent=True,
+            severity=IssueSeverity.WARNING,
+            translation_key="legacy_client_id",
+            translation_placeholders={
+                "title": entry.title,
+            },
+        )
 
     await asyncio.gather(
         *[async_do_first_refresh(coordinator) for coordinator in coordinators.values()]

--- a/custom_components/smartcar/application_credentials.py
+++ b/custom_components/smartcar/application_credentials.py
@@ -1,20 +1,93 @@
-from homeassistant.components.application_credentials import AuthorizationServer
+from dataclasses import dataclass
+from typing import cast
+
+from homeassistant.components.application_credentials import (
+    AuthImplementation,
+    AuthorizationServer,
+    ClientCredential,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import (
     AUTH_CALLBACK_PATH,
     MY_AUTH_CALLBACK_PATH,
+    AbstractOAuth2Implementation,
 )
 
-from .const import OAUTH2_AUTHORIZE, OAUTH2_TOKEN
+from .const import OAUTH2_AUTHORIZE, OAUTH2_TOKEN, OAUTH2_TOKEN_LEGACY
+from .util import api_version_for_client_id
+
+
+@dataclass
+class SmartcarAuthorizationServer(AuthorizationServer):
+    """Represent Smartcar OAuth2 Authorization Server(s)."""
+
+    token_url_v2: str
+
+
+class SmartcarAuthImplementation(AuthImplementation):
+    """Smartcar local OAuth2 implementation."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        auth_domain: str,
+        credential: ClientCredential,
+        authorization_server: AuthorizationServer,
+    ) -> None:
+        """Initialize AuthImplementation."""
+        super().__init__(
+            hass,
+            auth_domain,
+            credential,
+            authorization_server,
+        )
+
+        if api_version_for_client_id(credential.client_id) == "v2":
+            self.token_url = authorization_server.token_url_v2
+
+    async def _token_request(self, data: dict) -> dict:
+        if api_version_for_client_id(self.client_id) == "v2":
+            return cast("dict", await super()._token_request(data))
+
+        session = async_get_clientsession(self.hass)
+        response = await session.post(
+            self.token_url,
+            json={
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "grant_type": "client_credentials",
+            },
+        )
+        data = await response.json()
+
+        assert data.get("token_type", "").lower() == "bearer", "Invalid token type."
+        assert data.get("access_token"), "Invalid access token."
+
+        return {"refresh_token": None, **data}
+
+
+async def async_get_auth_implementation(
+    hass: HomeAssistant,
+    auth_domain: str,
+    credential: ClientCredential,
+) -> AbstractOAuth2Implementation:
+    return SmartcarAuthImplementation(
+        hass,
+        auth_domain,
+        credential,
+        authorization_server=await async_get_authorization_server(hass),
+    )
 
 
 async def async_get_authorization_server(  # noqa: RUF029
     hass: HomeAssistant,  # noqa: ARG001
 ) -> AuthorizationServer:
     """Return authorization server details."""
-    return AuthorizationServer(
+    return SmartcarAuthorizationServer(
         authorize_url=OAUTH2_AUTHORIZE,
         token_url=OAUTH2_TOKEN,
+        token_url_v2=OAUTH2_TOKEN_LEGACY,
     )
 
 

--- a/custom_components/smartcar/auth.py
+++ b/custom_components/smartcar/auth.py
@@ -3,6 +3,8 @@ import logging
 
 from aiohttp import ClientResponse, ClientSession
 
+from .types import APIVersion
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -14,20 +16,58 @@ _LOGGER = logging.getLogger(__name__)
 class AbstractAuth(ABC):
     """Abstract class to make authenticated requests."""
 
-    def __init__(self, websession: ClientSession, host: str) -> None:
+    def __init__(
+        self,
+        websession: ClientSession,
+        endpoints: dict[APIVersion, str],
+        *,
+        version: APIVersion,
+        user_id: str | None = None,
+    ) -> None:
         """Initialize the auth."""
         self._websession = websession
-        self._host = host
+        self._endpoints = endpoints
+        self._version = version
+        self._user_id = user_id
+
+    @property
+    def user_id(self) -> str | None:
+        return self._user_id
+
+    @user_id.setter
+    def user_id(self, user_id: str) -> None:
+        self._user_id = user_id
+
+    @property
+    def version(self) -> APIVersion:
+        """API version these credentials will work for."""
+        return self._version
 
     @abstractmethod
     async def async_get_access_token(self) -> str:
         """Return a valid access token."""
 
+    async def request_v2(
+        self,
+        method: str,
+        path: str,
+        **kwargs,  # noqa: ANN003
+    ) -> ClientResponse:
+        return await self.request(method, path, version="v2", **kwargs)
+
+    async def request_v3(
+        self,
+        method: str,
+        path: str,
+        **kwargs,  # noqa: ANN003
+    ) -> ClientResponse:
+        return await self.request(method, path, version="v3", **kwargs)
+
     async def request(
         self,
         method: str,
         path: str,
-        version: str = "2.0",
+        version: APIVersion,
         **kwargs,  # noqa: ANN003
     ) -> ClientResponse:
         """Make a request.
@@ -35,15 +75,21 @@ class AbstractAuth(ABC):
         Returns:
             The client response.
         """
+        assert version == self.version, (
+            f"Cannot use {version} API with {self.version} credentials"
+        )
+
         access_token = await self.async_get_access_token()
         headers = dict(kwargs.pop("headers", {}))
         headers["authorization"] = f"Bearer {access_token}"
 
+        if self.user_id is not None:
+            headers["sc-user-id"] = self.user_id
+
         _LOGGER.debug(
-            "HTTP %s request %s/v%s/%s %r headers=%r",
+            "HTTP %s request %s/%s %r headers=%r",
             method,
-            self._host,
-            version,
+            self._endpoints[version],
             path,
             kwargs,
             headers,
@@ -51,7 +97,7 @@ class AbstractAuth(ABC):
 
         return await self._websession.request(
             method,
-            f"{self._host}/v{version}/{path}",
+            f"{self._endpoints[version]}/{path}",
             **kwargs,
             headers=headers,
         )

--- a/custom_components/smartcar/auth_impl.py
+++ b/custom_components/smartcar/auth_impl.py
@@ -1,9 +1,14 @@
 from typing import cast
 
 from aiohttp import ClientSession
-from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    LocalOAuth2Implementation,
+    OAuth2Session,
+)
 
 from .auth import AbstractAuth
+from .types import APIVersion
+from .util import api_version_for_client_id
 
 
 class AsyncConfigEntryAuth(AbstractAuth):
@@ -12,11 +17,20 @@ class AsyncConfigEntryAuth(AbstractAuth):
     def __init__(
         self,
         websession: ClientSession,
+        implementation: LocalOAuth2Implementation,
         oauth_session: OAuth2Session,
-        host: str,
+        endpoints: dict[APIVersion, str],
+        *,
+        user_id: str | None = None,
     ) -> None:
         """Initialize Smartcar auth."""
-        super().__init__(websession, host)
+        super().__init__(
+            websession,
+            endpoints,
+            version=api_version_for_client_id(implementation.client_id),
+            user_id=user_id,
+        )
+        self._oauth_impl = implementation
         self._oauth_session = oauth_session
 
     async def async_get_access_token(self) -> str:
@@ -37,10 +51,13 @@ class AccessTokenAuthImpl(AbstractAuth):
         self,
         websession: ClientSession,
         access_token: str,
-        host: str,
+        endpoints: dict[APIVersion, str],
+        *,
+        version: APIVersion,
+        user_id: str | None = None,
     ) -> None:
-        """Init the Nest client library auth implementation."""
-        super().__init__(websession, host)
+        """Initialize Smartcar auth with pre-defined access token."""
+        super().__init__(websession, endpoints, version=version, user_id=user_id)
         self._access_token = access_token
 
     async def async_get_access_token(self) -> str:

--- a/custom_components/smartcar/binary_sensor.py
+++ b/custom_components/smartcar/binary_sensor.py
@@ -24,6 +24,17 @@ from .entity import SmartcarEntity, SmartcarEntityDescription
 _LOGGER = logging.getLogger(__name__)
 
 
+def _hvac_bool(body: object) -> object:
+    """Extract a boolean from an HVAC webhook signal body ({"value": bool}).
+
+    Returns:
+        The extracted boolean or the body unchanged.
+    """
+    if isinstance(body, dict):
+        return body.get("value")
+    return body
+
+
 @dataclass(frozen=True, kw_only=True)
 class SmartcarBinarySensorDescription(
     BinarySensorEntityDescription, SmartcarEntityDescription
@@ -294,6 +305,39 @@ SENSOR_TYPES: tuple[BinarySensorEntityDescription, ...] = (
         name="Fast Charger Connected",
         value_key_path="charge-isfastchargerpresent.value",
         device_class=BinarySensorDeviceClass.PLUG,
+    ),
+    # --- Climate status (read_climate) ---
+    SmartcarBinarySensorDescription(
+        key=EntityDescriptionKey.IS_CABIN_HVAC_ACTIVE,
+        name="Cabin HVAC Active",
+        value_key_path="hvac-iscabinhvacactive",
+        value_cast=_hvac_bool,
+        device_class=BinarySensorDeviceClass.RUNNING,
+        icon="mdi:air-conditioner",
+    ),
+    SmartcarBinarySensorDescription(
+        key=EntityDescriptionKey.IS_FRONT_DEFROSTER_ACTIVE,
+        name="Front Defroster Active",
+        value_key_path="hvac-isfrontdefrosteractive",
+        value_cast=_hvac_bool,
+        device_class=BinarySensorDeviceClass.RUNNING,
+        icon="mdi:car-defrost-front",
+    ),
+    SmartcarBinarySensorDescription(
+        key=EntityDescriptionKey.IS_REAR_DEFROSTER_ACTIVE,
+        name="Rear Defroster Active",
+        value_key_path="hvac-isreardefrosteractive",
+        value_cast=_hvac_bool,
+        device_class=BinarySensorDeviceClass.RUNNING,
+        icon="mdi:car-defrost-rear",
+    ),
+    SmartcarBinarySensorDescription(
+        key=EntityDescriptionKey.IS_STEERING_HEATER_ACTIVE,
+        name="Steering Wheel Heater Active",
+        value_key_path="hvac-issteeringheateractive",
+        value_cast=_hvac_bool,
+        device_class=BinarySensorDeviceClass.RUNNING,
+        icon="mdi:steering",
     ),
 )
 

--- a/custom_components/smartcar/config_flow.py
+++ b/custom_components/smartcar/config_flow.py
@@ -170,11 +170,12 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
         )
 
     def _initial_data(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
         if self.source == SOURCE_REAUTH:
-            return self._get_reauth_entry().data
+            result = self._get_reauth_entry().data
         if self.source == SOURCE_RECONFIGURE:
-            return self._get_reconfigure_entry().data
-        return {}
+            result = self._get_reconfigure_entry().data
+        return result
 
     @property
     def selected_scopes(self) -> list[Scope]:

--- a/custom_components/smartcar/config_flow.py
+++ b/custom_components/smartcar/config_flow.py
@@ -15,7 +15,11 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_TOKEN, CONF_WEBHOOK_ID
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.config_entry_oauth2_flow import AbstractOAuth2FlowHandler
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    AbstractOAuth2FlowHandler,
+    AbstractOAuth2Implementation,
+    async_get_config_entry_implementation,
+)
 from homeassistant.helpers.selector import (
     TextSelector,
     TextSelectorConfig,
@@ -26,7 +30,8 @@ import voluptuous as vol
 from . import populate_entry_data, vehicle_vins_in_use
 from .auth_impl import AccessTokenAuthImpl
 from .const import (
-    API_HOST,
+    API_ENDPOINTS,
+    CONF_APPLICATION_ID,
     CONF_APPLICATION_MANAGEMENT_TOKEN,
     CONF_CLOUDHOOK,
     CONFIGURABLE_SCOPES,
@@ -37,8 +42,17 @@ from .const import (
     SMARTCAR_MODE,
     Scope,
 )
-from .errors import EmptyVehicleListError, InvalidAuthError, MissingVINError
-from .util import unique_id_from_entry_data, vins_from_entry_data
+from .errors import (
+    EmptyVehicleListError,
+    InvalidAuthError,
+    MissingVINError,
+    UnsupportedUserConfigurationError,
+)
+from .util import (
+    api_version_for_client_id,
+    unique_id_from_entry_data,
+    vins_from_entry_data,
+)
 from .webhooks import webhook_url_from_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,10 +60,13 @@ _LOGGER = logging.getLogger(__name__)
 CONF_USE_WEBHOOKS = "use_webhooks"
 
 GENERAL_CONFIGURATION_SCHEMA = {
-    vol.Required(CONF_USE_WEBHOOKS, default=True): bool,
+    vol.Optional(CONF_APPLICATION_ID): TextSelector(
+        config=TextSelectorConfig(type=TextSelectorType.TEXT)
+    ),
     vol.Optional(CONF_APPLICATION_MANAGEMENT_TOKEN): TextSelector(
         config=TextSelectorConfig(type=TextSelectorType.TEXT)
     ),
+    vol.Required(CONF_USE_WEBHOOKS, default=True): bool,
 }
 BASE_DESCRIPTION_PLACEHOLDERS = {
     "webhook_url": "webhooks-not-enabled",
@@ -60,8 +77,10 @@ BASE_DESCRIPTION_PLACEHOLDERS = {
 
 def _validate_general_configuration_input(
     user_input: dict[str, Any],
+    flow_impl: AbstractOAuth2Implementation,
     errors: dict[str, str],
 ) -> None:
+    application_id = user_input.get(CONF_APPLICATION_ID)
     use_webhooks = user_input[CONF_USE_WEBHOOKS]
     management_token = user_input.get(CONF_APPLICATION_MANAGEMENT_TOKEN)
 
@@ -70,6 +89,9 @@ def _validate_general_configuration_input(
 
     if not use_webhooks and management_token:
         errors["base"] = "extraneous_management_token"
+
+    if not application_id and api_version_for_client_id(flow_impl.client_id) == "v3":
+        errors["base"] = "no_application_id"
 
     if not management_token:
         user_input.pop(CONF_APPLICATION_MANAGEMENT_TOKEN, None)
@@ -117,10 +139,35 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
     def extra_authorize_data(self) -> dict[str, Any]:
         """Extra data that needs to be appended to the authorize url."""
 
+        assert self.entry_data is not None
+
         return {
             "mode": SMARTCAR_MODE,
             "scope": " ".join(self.requested_scopes),
-        }
+        } | (
+            {
+                # for v3, smartcar shifted to what they refer to as application-
+                # level access tokens. they use oauth to describe their auth
+                # scheme, but this is something seemingly much more customized
+                # or specific to their end goals as it's different from most
+                # flows. in particular:
+                #
+                #   - client_id is actually expected to be the application_id.
+                #   - client_id is not used here at all & instead only used
+                #     for token requests (which happen outside of the oauth
+                #     flow).
+                #   - the flow is used to add a connection for a user and a
+                #     vehicle.
+                #   - the resulting token is basically discarded.
+                #   - a non-standard `user_id` is included in the redirect URL
+                #     which they expect will be captured & used for future
+                #     requests. (this allows a backend app to determine the
+                #     correct end-user in multi-user app configurations).
+                "client_id": self.entry_data.get(CONF_APPLICATION_ID, ""),
+            }
+            if api_version_for_client_id(self.flow_impl.client_id) == "v3"
+            else {}
+        )
 
     def _initial_data(self) -> dict[str, Any]:
         return self._get_reauth_entry().data if self.source == SOURCE_REAUTH else {}
@@ -155,7 +202,7 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
 
         if user_input is not None:
             user_input = {**user_input}
-            _validate_general_configuration_input(user_input, errors)
+            _validate_general_configuration_input(user_input, self.flow_impl, errors)
 
         if user_input is not None and not errors:
             self.entry_data = {**user_input}
@@ -252,7 +299,12 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
 
         session = async_get_clientsession(self.hass)
         token = data[CONF_TOKEN][CONF_ACCESS_TOKEN]
-        auth = AccessTokenAuthImpl(session, token, API_HOST)
+        auth = AccessTokenAuthImpl(
+            session,
+            token,
+            API_ENDPOINTS,
+            version=api_version_for_client_id(self.flow_impl.client_id),
+        )
         data = {**self.entry_data, **data}
         data.pop(CONF_USE_WEBHOOKS, None)
         description_placeholders = {**BASE_DESCRIPTION_PLACEHOLDERS}
@@ -266,6 +318,11 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
         except EmptyVehicleListError:
             _LOGGER.exception("No vehicles returned")
             return self.async_abort(reason="no_vehicles")
+        except UnsupportedUserConfigurationError:
+            _LOGGER.exception(
+                "Unsupported user configuration detected; expected single user"
+            )
+            return self.async_abort(reason="not_single_user_app")
         except MissingVINError:
             _LOGGER.exception("Missing vehicle VIN")
             return self.async_abort(reason="unknown")
@@ -368,7 +425,10 @@ class SmartcarOptionsFlow(OptionsFlow):
 
         if user_input is not None:
             user_input = {**user_input}
-            _validate_general_configuration_input(user_input, errors)
+            impl = await async_get_config_entry_implementation(
+                self.hass, self.config_entry
+            )
+            _validate_general_configuration_input(user_input, impl, errors)
 
         if user_input is not None and not errors:
             entry_data.pop(CONF_APPLICATION_MANAGEMENT_TOKEN, None)

--- a/custom_components/smartcar/config_flow.py
+++ b/custom_components/smartcar/config_flow.py
@@ -45,7 +45,6 @@ from .const import (
 from .errors import (
     EmptyVehicleListError,
     InvalidAuthError,
-    MissingVINError,
     UnsupportedUserConfigurationError,
 )
 from .util import (
@@ -323,9 +322,6 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
                 "Unsupported user configuration detected; expected single user"
             )
             return self.async_abort(reason="not_single_user_app")
-        except MissingVINError:
-            _LOGGER.exception("Missing vehicle VIN")
-            return self.async_abort(reason="unknown")
         except InvalidAuthError:
             _LOGGER.exception("Failed to authenticate")
             return self.async_abort(reason="invalid_access_token")
@@ -342,7 +338,7 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
         duplicate_vins = [
             details["vin"]
             for details in data.get("vehicles", {}).values()
-            if details["vin"] in other_vins
+            if details.get("vin") in other_vins
         ]
 
         if duplicate_vins:

--- a/custom_components/smartcar/config_flow.py
+++ b/custom_components/smartcar/config_flow.py
@@ -8,6 +8,7 @@ from aiohttp import ClientConnectorError, ClientError
 from homeassistant.components import cloud, webhook
 from homeassistant.config_entries import (
     SOURCE_REAUTH,
+    SOURCE_RECONFIGURE,
     ConfigEntry,
     ConfigFlowResult,
     OptionsFlow,
@@ -169,7 +170,11 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
         )
 
     def _initial_data(self) -> dict[str, Any]:
-        return self._get_reauth_entry().data if self.source == SOURCE_REAUTH else {}
+        if self.source == SOURCE_REAUTH:
+            return self._get_reauth_entry().data
+        if self.source == SOURCE_RECONFIGURE:
+            return self._get_reconfigure_entry().data
+        return {}
 
     @property
     def selected_scopes(self) -> list[Scope]:
@@ -269,6 +274,20 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
             return await self.async_step_webhooks()
         return await super().async_step_auth(user_input)
 
+    async def async_step_reconfigure(
+        self,
+        user_input: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of an existing entry.
+
+        Replays the customized flow (webhooks then scopes) before re-running
+        the OAuth authorization so permissions can be changed after setup.
+
+        Returns:
+            The config flow result.
+        """
+        return await self.async_step_user()
+
     async def async_step_reauth(
         self,
         entry_data: Mapping[str, Any],  # noqa: ARG002
@@ -331,10 +350,15 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
 
         await self.async_set_unique_id(unique_id_from_entry_data(data))
 
-        other_vins = vehicle_vins_in_use(
-            self.hass,
-            self._get_reauth_entry() if self.source == SOURCE_REAUTH else None,
+        current_entry = (
+            self._get_reauth_entry()
+            if self.source == SOURCE_REAUTH
+            else self._get_reconfigure_entry()
+            if self.source == SOURCE_RECONFIGURE
+            else None
         )
+
+        other_vins = vehicle_vins_in_use(self.hass, current_entry)
         duplicate_vins = [
             details["vin"]
             for details in data.get("vehicles", {}).values()
@@ -348,8 +372,6 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
             )
 
         if self.source == SOURCE_REAUTH:
-            reauth_entry = self._get_reauth_entry()
-
             self._abort_if_unique_id_mismatch(
                 reason="wrong_vehicles",
                 description_placeholders={
@@ -358,16 +380,27 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
             )
 
             return self.async_update_reload_and_abort(
-                reauth_entry, data={**self._initial_data(), **data}
+                current_entry, data={**self._initial_data(), **data}
             )
 
-        self._abort_if_unique_id_configured()
+        if self.source == SOURCE_RECONFIGURE:
+            self._abort_if_unique_id_mismatch(
+                reason="wrong_vehicles",
+                description_placeholders={
+                    "vins": vins_from_entry_data(self._initial_data())
+                },
+            )
+        else:
+            self._abort_if_unique_id_configured()
 
         # populate webhook details
         if CONF_APPLICATION_MANAGEMENT_TOKEN in data:
             try:
                 webhook_id, webhook_url, cloudhook = await _get_webhook_details(
-                    self.hass
+                    self.hass,
+                    self._initial_data().get(CONF_WEBHOOK_ID)
+                    if self.source == SOURCE_RECONFIGURE
+                    else None,
                 )
             except cloud.CloudNotConnected:
                 return self.async_abort(reason="cloud_not_connected")
@@ -380,6 +413,20 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
                 **description_placeholders,
                 "webhook_url": webhook_url,
             }
+
+        if self.source == SOURCE_RECONFIGURE:
+            reconfigure_data = {**self._initial_data(), **data}
+            if CONF_APPLICATION_MANAGEMENT_TOKEN not in data:
+                # webhooks were disabled during reconfigure; drop stale details
+                reconfigure_data.pop(CONF_APPLICATION_MANAGEMENT_TOKEN, None)
+                reconfigure_data.pop(CONF_WEBHOOK_ID, None)
+                reconfigure_data.pop(CONF_CLOUDHOOK, None)
+
+            return self.async_update_reload_and_abort(
+                current_entry,
+                data=reconfigure_data,
+                reason="reconfigure_successful",
+            )
 
         return self.async_create_entry(
             title=DEFAULT_NAME,

--- a/custom_components/smartcar/const.py
+++ b/custom_components/smartcar/const.py
@@ -1,8 +1,13 @@
 from enum import StrEnum, auto
 
+from .types import APIVersion
+
 DOMAIN = "smartcar"
 DEFAULT_NAME = "Smartcar"
-API_HOST = "https://api.smartcar.com"
+API_ENDPOINT = "https://vehicle.api.smartcar.com/v3"
+API_ENDPOINT_LEGACY = "https://api.smartcar.com/v2.0"
+API_ENDPOINTS: dict[APIVersion, str] = {"v2": API_ENDPOINT_LEGACY, "v3": API_ENDPOINT}
+
 
 PLATFORMS = [
     "sensor",
@@ -14,9 +19,11 @@ PLATFORMS = [
 ]
 
 OAUTH2_AUTHORIZE = "https://connect.smartcar.com/oauth/authorize"
-OAUTH2_TOKEN = "https://auth.smartcar.com/oauth/token"  # noqa: S105
+OAUTH2_TOKEN = "https://iam.smartcar.com/oauth2/token"  # noqa: S105
+OAUTH2_TOKEN_LEGACY = "https://auth.smartcar.com/oauth/token"  # noqa: S105
 SMARTCAR_MODE = "live"
 
+CONF_APPLICATION_ID = "application_id"
 CONF_APPLICATION_MANAGEMENT_TOKEN = "application_management_token"  # noqa: S105
 CONF_CLOUDHOOK = "cloudhook"
 

--- a/custom_components/smartcar/const.py
+++ b/custom_components/smartcar/const.py
@@ -43,6 +43,9 @@ class Scope(StrEnum):
     READ_TIRES = auto()
     CONTROL_CHARGE = auto()
     CONTROL_SECURITY = auto()
+    READ_DIAGNOSTICS = auto()
+    READ_CLIMATE = auto()
+    CONTROL_CLIMATE = auto()
 
 
 REQUIRED_SCOPES = [
@@ -61,6 +64,9 @@ DEFAULT_SCOPES = [
     Scope.READ_VEHICLE_INFO,
     Scope.READ_VIN,
     Scope.CONTROL_CHARGE,
+    Scope.READ_DIAGNOSTICS,
+    Scope.READ_CLIMATE,
+    Scope.CONTROL_CLIMATE,
 ]
 
 
@@ -121,6 +127,23 @@ class EntityDescriptionKey(StrEnum):
     CHARGE_FAST_CHARGER_PRESENT = auto()
     FIRMWARE_VERSION = auto()
     LAST_WEBHOOK_RECEIVED = auto()
+    # Diagnostics (requires read_diagnostics)
+    DIAG_ABS = auto()
+    DIAG_MIL = auto()
+    DIAG_DTC_COUNT = auto()
+    DIAG_DTC_LIST = auto()
+    DIAG_EV_BATTERY_CONDITIONING = auto()
+    DIAG_EV_CHARGING = auto()
+    DIAG_EV_DRIVE_UNIT = auto()
+    DIAG_EV_HV_BATTERY = auto()
+    # Climate status (requires read_climate)
+    CABIN_TARGET_TEMPERATURE = auto()
+    IS_CABIN_HVAC_ACTIVE = auto()
+    IS_FRONT_DEFROSTER_ACTIVE = auto()
+    IS_REAR_DEFROSTER_ACTIVE = auto()
+    IS_STEERING_HEATER_ACTIVE = auto()
+    # Climate control (requires read_climate + control_climate)
+    CLIMATE = auto()
 
 
 DEFAULT_ENABLED_ENTITY_DESCRIPTION_KEYS = {
@@ -131,4 +154,18 @@ DEFAULT_ENABLED_ENTITY_DESCRIPTION_KEYS = {
     EntityDescriptionKey.LOCATION,
     EntityDescriptionKey.PLUG_STATUS,
     EntityDescriptionKey.RANGE,
+    EntityDescriptionKey.DIAG_ABS,
+    EntityDescriptionKey.DIAG_MIL,
+    EntityDescriptionKey.DIAG_DTC_COUNT,
+    EntityDescriptionKey.DIAG_DTC_LIST,
+    EntityDescriptionKey.DIAG_EV_BATTERY_CONDITIONING,
+    EntityDescriptionKey.DIAG_EV_CHARGING,
+    EntityDescriptionKey.DIAG_EV_DRIVE_UNIT,
+    EntityDescriptionKey.DIAG_EV_HV_BATTERY,
+    EntityDescriptionKey.CABIN_TARGET_TEMPERATURE,
+    EntityDescriptionKey.IS_CABIN_HVAC_ACTIVE,
+    EntityDescriptionKey.IS_FRONT_DEFROSTER_ACTIVE,
+    EntityDescriptionKey.IS_REAR_DEFROSTER_ACTIVE,
+    EntityDescriptionKey.IS_STEERING_HEATER_ACTIVE,
+    EntityDescriptionKey.CLIMATE,
 }

--- a/custom_components/smartcar/coordinator.py
+++ b/custom_components/smartcar/coordinator.py
@@ -48,6 +48,18 @@ VEHICLE_RIGHT_COLUMN = 1
 
 UPDATE_INTERVAL = timedelta(hours=6)
 
+# Signal error conditions that are structural or otherwise expected for a given
+# vehicle and therefore recur on every update (e.g. a vehicle that is simply not
+# capable of a signal, or charge signals while not charging). Logging these at
+# ERROR floods the log with permanent noise, so they are demoted to DEBUG.
+# Genuine/actionable errors keep their original level.
+_BENIGN_SIGNAL_ERRORS: frozenset[tuple[str | None, str | None]] = frozenset(
+    {
+        ("COMPATIBILITY", "VEHICLE_NOT_CAPABLE"),
+        ("VEHICLE_STATE", "NOT_CHARGING"),
+    }
+)
+
 
 @dataclass
 class DatapointConfig:
@@ -477,6 +489,51 @@ DATAPOINT_ENTITY_KEY_MAP = {
         [],
         None,
         None,
+    ),
+    # Diagnostics (webhook-only, require read_diagnostics)
+    EntityDescriptionKey.DIAG_ABS: DatapointConfig(
+        "diagnostics-abs", ["read_diagnostics"], None, None
+    ),
+    EntityDescriptionKey.DIAG_MIL: DatapointConfig(
+        "diagnostics-mil", ["read_diagnostics"], None, None
+    ),
+    EntityDescriptionKey.DIAG_DTC_COUNT: DatapointConfig(
+        "diagnostics-dtccount", ["read_diagnostics"], None, None
+    ),
+    EntityDescriptionKey.DIAG_DTC_LIST: DatapointConfig(
+        "diagnostics-dtclist", ["read_diagnostics"], None, None
+    ),
+    EntityDescriptionKey.DIAG_EV_BATTERY_CONDITIONING: DatapointConfig(
+        "diagnostics-evbatteryconditioning", ["read_diagnostics"], None, None
+    ),
+    EntityDescriptionKey.DIAG_EV_CHARGING: DatapointConfig(
+        "diagnostics-evcharging", ["read_diagnostics"], None, None
+    ),
+    EntityDescriptionKey.DIAG_EV_DRIVE_UNIT: DatapointConfig(
+        "diagnostics-evdriveunit", ["read_diagnostics"], None, None
+    ),
+    EntityDescriptionKey.DIAG_EV_HV_BATTERY: DatapointConfig(
+        "diagnostics-evhvbattery", ["read_diagnostics"], None, None
+    ),
+    # Climate status (webhook-only, require read_climate)
+    EntityDescriptionKey.CABIN_TARGET_TEMPERATURE: DatapointConfig(
+        "hvac-cabintargettemperature", ["read_climate"], None, None
+    ),
+    EntityDescriptionKey.IS_CABIN_HVAC_ACTIVE: DatapointConfig(
+        "hvac-iscabinhvacactive", ["read_climate"], None, None
+    ),
+    EntityDescriptionKey.IS_FRONT_DEFROSTER_ACTIVE: DatapointConfig(
+        "hvac-isfrontdefrosteractive", ["read_climate"], None, None
+    ),
+    EntityDescriptionKey.IS_REAR_DEFROSTER_ACTIVE: DatapointConfig(
+        "hvac-isreardefrosteractive", ["read_climate"], None, None
+    ),
+    EntityDescriptionKey.IS_STEERING_HEATER_ACTIVE: DatapointConfig(
+        "hvac-issteeringheateractive", ["read_climate"], None, None
+    ),
+    # Climate control switch (reads HVAC-active state, requires control_climate)
+    EntityDescriptionKey.CLIMATE: DatapointConfig(
+        "hvac-iscabinhvacactive", ["read_climate", "control_climate"], None, None
     ),
 }
 
@@ -1001,6 +1058,9 @@ def _handle_webhook_signal_error(
 ) -> None:
     error_type = error.get("type")
     error_code = error.get("code")
+
+    if (error_type, error_code) in _BENIGN_SIGNAL_ERRORS:
+        level = "debug"
 
     logger_method = getattr(_LOGGER, level)
     logger_method("error for signal %s: %s:%s", signal_name, error_type, error_code)

--- a/custom_components/smartcar/coordinator.py
+++ b/custom_components/smartcar/coordinator.py
@@ -26,6 +26,7 @@ from homeassistant.util import dt as dt_util
 from . import util
 from .auth import AbstractAuth
 from .const import CONF_APPLICATION_MANAGEMENT_TOKEN, DOMAIN, EntityDescriptionKey
+from .types import APIVersion
 from .util import key_path_get, key_path_update
 
 _LOGGER = logging.getLogger(__name__)
@@ -509,23 +510,26 @@ class SmartcarVehicleCoordinator(DataUpdateCoordinator):
     def __init__(
         self,
         hass: HomeAssistant,
+        *,
         auth: AbstractAuth,
         vehicle_id: str,
         vin: str,
         entry: ConfigEntry,
+        version: APIVersion,
     ) -> None:
         """Initialize coordinator."""
         self.auth = auth
         self.vehicle_id = vehicle_id
         self.vin = vin
         self.entry = entry
+        self.version = version
         self.batch_requests: set[EntityDescriptionKey] = set()
         self.data: dict[str, Any] = {}
 
         super().__init__(
             hass,
             _LOGGER,
-            name=f"{DOMAIN}_{vin}",
+            name=f"{DOMAIN}_{vehicle_id}",
             update_interval=UPDATE_INTERVAL
             if CONF_APPLICATION_MANAGEMENT_TOKEN not in entry.data
             else None,

--- a/custom_components/smartcar/coordinator.py
+++ b/custom_components/smartcar/coordinator.py
@@ -651,7 +651,7 @@ class SmartcarVehicleCoordinator(DataUpdateCoordinator):
 
         try:
             response = await util.async_request_with_retry(
-                lambda: self.auth.request("post", request_path, json=request_body),
+                lambda: self.auth.request_v2("post", request_path, json=request_body),
                 logger=_LOGGER,
                 context=f"Coordinator {self.name}",
             )

--- a/custom_components/smartcar/coordinator.py
+++ b/custom_components/smartcar/coordinator.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
+import copy
 from dataclasses import dataclass
 import datetime as dt
 from datetime import timedelta
 from http import HTTPStatus
 import logging
 import numbers
-from typing import Any
+from typing import Any, Literal
 
 from aiohttp import ClientResponseError
 from homeassistant.config_entries import ConfigEntry
@@ -28,6 +29,16 @@ from .const import CONF_APPLICATION_MANAGEMENT_TOKEN, DOMAIN, EntityDescriptionK
 from .util import key_path_get, key_path_update
 
 _LOGGER = logging.getLogger(__name__)
+
+# values from the smartcar service that denote an imperial measurement and can
+# be converted by one of the imperial_conversion functions defined on an entity
+# description.
+_IMPERIAL_MEASUREMENTS = {"miles", "psi", "gallons"}
+
+
+_SIGNAL_BODY_MULTIVALUE_ITEM_KEY_MAP: dict[str | None, str] = {
+    "charge-chargelimits": "limit",
+}
 
 VEHICLE_FRONT_ROW = 0
 VEHICLE_BACK_ROW = 1
@@ -650,11 +661,22 @@ class SmartcarVehicleCoordinator(DataUpdateCoordinator):
         )
 
         try:
-            response = await util.async_request_with_retry(
-                lambda: self.auth.request_v2("post", request_path, json=request_body),
-                logger=_LOGGER,
-                context=f"Coordinator {self.name}",
-            )
+            if self.auth.version == "v2":
+                response = await util.async_request_with_retry(
+                    lambda: self.auth.request_v2(
+                        "post", request_path, json=request_body
+                    ),
+                    logger=_LOGGER,
+                    context=f"Coordinator {self.name}",
+                )
+            else:
+                assert self.auth.version == "v3"
+                request_path = f"vehicles/{self.vehicle_id}/signals"
+                response = await util.async_request_with_retry(
+                    lambda: self.auth.request_v3("get", request_path),
+                    logger=_LOGGER,
+                    context=f"Coordinator {self.name}",
+                )
 
         # response errors here for responses that have actually completed, i.e.
         # 4xx responses are for errors related to requests made in the
@@ -681,11 +703,14 @@ class SmartcarVehicleCoordinator(DataUpdateCoordinator):
         response.raise_for_status()
         response_data = await response.json()
 
-        if "responses" not in response_data:
-            msg = "Invalid batch response format"
-            raise UpdateFailed(msg)
+        if self.auth.version == "v2":
+            if "responses" not in response_data:
+                msg = "Invalid batch response format"
+                raise UpdateFailed(msg)
 
-        return self._merge_batch_data(response_data)
+            return self._merge_batch_data(response_data)
+        assert self.auth.version == "v3"
+        return self._merge_signal_data(response_data)
 
     def _merge_batch_data(self, batch_data: dict[str, Any]) -> dict[str, Any]:
         """Merge data from the responses from a batch request.
@@ -736,6 +761,20 @@ class SmartcarVehicleCoordinator(DataUpdateCoordinator):
 
             return updated_data
 
+    def _merge_signal_data(self, signal_data: dict[str, Any]) -> dict[str, Any]:
+        """Merge data response data from a v3 vehicle signals request.
+
+        Returns:
+            The newly merged data.
+        """
+        with self.create_updated_data() as (add, updated_data):
+            for signal in signal_data.get("data", []):
+                add.from_signal_attributes(signal.get("attributes", {}))
+
+            _LOGGER.debug("Coordinator %s: Signal polling update processed", self.name)
+
+            return updated_data
+
     @contextmanager
     def create_updated_data(
         self,
@@ -749,6 +788,59 @@ class _DataAdder:
     def __init__(self, data: dict[str, Any]) -> None:
         super().__init__()
         self.data = data
+        self._addition_made = False
+
+    @property
+    def addition_made(self) -> bool:
+        return self._addition_made
+
+    def from_signal_attributes(self, signal: dict) -> None:
+        name: str | None = signal.get("name")
+        status = signal.get("status", {})
+        is_error = status.get("value") == "ERROR"
+        code: str | None = signal.get("code")
+        body = copy.deepcopy(signal.get("body", {}))
+        meta = signal.get("meta", {})
+
+        if is_error:
+            _handle_webhook_signal_error(
+                name,
+                status.get("error", {}),
+                level="error" if _is_integrated(signal) else "debug",
+            )
+
+            body = {"value": None}
+
+        if body.get("unit") == "percent":
+            _handle_percent_unit_conversion(code, body)
+
+        if code in DATAPOINT_CODE_MAP:
+            assert code is not None
+
+            data_age = meta.get("oemUpdatedAt") if not is_error else None
+            fetched_at = meta.get("retrievedAt") if not is_error else None
+            unit = body.pop("unit", None)
+            unit_system = (
+                "imperial"
+                if unit in _IMPERIAL_MEASUREMENTS
+                else "metric"
+                if unit
+                else None
+            )
+
+            if data_age:
+                data_age = dt_util.utc_from_timestamp(data_age / 1000)
+            if fetched_at:
+                fetched_at = dt_util.utc_from_timestamp(fetched_at / 1000)
+
+            self.from_response_body(
+                code,
+                body=body,
+                unit_system=unit_system,
+                data_age=data_age,
+                fetched_at=fetched_at,
+                can_clear_meta=not is_error,
+            )
 
     def from_response_body(
         self,
@@ -859,6 +951,8 @@ class _DataAdder:
         unit_system: str | None,
         can_clear: bool,
     ) -> None:
+        self._addition_made = True
+
         for datapoint in datapoints:
             storage_key = datapoint.storage_key
 
@@ -876,3 +970,33 @@ class _DataAdder:
                 self.data[f"{storage_key}:fetched_at"] = fetched_at
             elif can_clear:
                 self.data.pop(f"{storage_key}:fetched_at", None)
+
+
+def _is_integrated(signal: dict) -> bool:
+    code: str | None = signal.get("code")
+    return code in DATAPOINT_CODE_MAP
+
+
+def _handle_percent_unit_conversion(code: str | None, body: dict[str, Any]) -> None:
+    if "values" in body:
+        item_key = _SIGNAL_BODY_MULTIVALUE_ITEM_KEY_MAP.get(code) or "value"
+        values = body["values"]
+        values = [value | {item_key: value[item_key] / 100} for value in values]
+        body["values"] = values
+        body.pop("unit")
+    else:
+        body["value"] /= 100
+        body.pop("unit")
+
+
+def _handle_webhook_signal_error(
+    signal_name: str | None,
+    error: dict,
+    *,
+    level: Literal["error", "debug"] = "error",
+) -> None:
+    error_type = error.get("type")
+    error_code = error.get("code")
+
+    logger_method = getattr(_LOGGER, level)
+    logger_method("error for signal %s: %s:%s", signal_name, error_type, error_code)

--- a/custom_components/smartcar/diagnostics.py
+++ b/custom_components/smartcar/diagnostics.py
@@ -74,6 +74,9 @@ async def async_get_config_entry_diagnostics(
                     coordinator_name: coordinator.data
                     for coordinator_name, coordinator in coordinators.items()
                 },
+                "version": next(
+                    iter(coordinator.version for coordinator in coordinators.values())
+                ),
                 "metadata": metadata,
             },
             TO_REDACT,

--- a/custom_components/smartcar/entity.py
+++ b/custom_components/smartcar/entity.py
@@ -42,10 +42,14 @@ class SmartcarEntity[ValueT, RawValueT](
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
-        self.vin = coordinator.vin
+        device_id = coordinator.vehicle_id
+
+        if coordinator.version == "v2" and coordinator.vin:
+            device_id = coordinator.vin
+
         self.entity_description = description
-        self._attr_unique_id = f"{self.vin}_{description.key}"
-        self._attr_device_info = {"identifiers": {(DOMAIN, self.vin)}}
+        self._attr_unique_id = f"{device_id}_{description.key}"
+        self._attr_device_info = {"identifiers": {(DOMAIN, device_id)}}
 
     @property
     def available(self) -> bool:
@@ -270,7 +274,12 @@ async def async_send_command(
     *,
     method: str = "post",
 ) -> bool:
-    _LOGGER.info("Sending %s request for %s", subpath, coordinator.vin)
+    _LOGGER.info(
+        "Sending %s request for %s (VIN: %s)",
+        subpath,
+        coordinator.vehicle_id,
+        coordinator.vin,
+    )
     success = False
     version = coordinator.auth.version
 
@@ -286,16 +295,17 @@ async def async_send_command(
                 json=payload,
             ),
             logger=_LOGGER,
-            context=f"Command {subpath} for {coordinator.vin}",
+            context=f"Command {subpath} for {coordinator.vehicle_id} (VIN : {coordinator.vin}",
         )
         resp.raise_for_status()
         success = True
     except ClientResponseError as err:
         if err.status == HTTPStatus.UNAUTHORIZED:
             _LOGGER.warning(
-                "Auth error %s sending %s request for %s",
+                "Auth error %s sending %s request for %s (VIN: %s)",
                 err.status,
                 subpath,
+                coordinator.vehicle_id,
                 coordinator.vin,
             )
             coordinator.config_entry.async_start_reauth(coordinator.hass)

--- a/custom_components/smartcar/entity.py
+++ b/custom_components/smartcar/entity.py
@@ -160,12 +160,11 @@ class SmartcarEntity[ValueT, RawValueT](
         payload: dict[str, Any],
         *,
         method: str = "post",
-        version: str = "2.0",
         **kwargs,  # noqa: ARG002, ANN003
     ) -> bool:
         try:
             return await async_send_command(
-                self.coordinator, subpath, payload, method=method, version=version
+                self.coordinator, subpath, payload, method=method
             )
         except SmartcarAPIError:
             return False
@@ -270,17 +269,15 @@ async def async_send_command(
     payload: dict[str, Any],
     *,
     method: str = "post",
-    version: str = "2.0",
 ) -> bool:
     _LOGGER.info("Sending %s request for %s", subpath, coordinator.vin)
     success = False
 
     try:
         resp = await util.async_request_with_retry(
-            lambda: coordinator.auth.request(
+            lambda: coordinator.auth.request_v2(
                 method,
                 f"vehicles/{coordinator.vehicle_id}{subpath}",
-                version=version,
                 json=payload,
             ),
             logger=_LOGGER,

--- a/custom_components/smartcar/entity.py
+++ b/custom_components/smartcar/entity.py
@@ -157,7 +157,7 @@ class SmartcarEntity[ValueT, RawValueT](
     async def _async_send_command(
         self,
         subpath: str,
-        payload: dict[str, Any],
+        payload: dict[str, Any] | None,
         *,
         method: str = "post",
         **kwargs,  # noqa: ARG002, ANN003
@@ -266,18 +266,23 @@ def inject_raw_value[RawValueT](
 async def async_send_command(
     coordinator: SmartcarVehicleCoordinator,
     subpath: str,
-    payload: dict[str, Any],
+    payload: dict[str, Any] | None,
     *,
     method: str = "post",
 ) -> bool:
     _LOGGER.info("Sending %s request for %s", subpath, coordinator.vin)
     success = False
+    version = coordinator.auth.version
+
+    if version == "v3":
+        subpath = f"/commands{subpath}"
 
     try:
         resp = await util.async_request_with_retry(
-            lambda: coordinator.auth.request_v2(
+            lambda: coordinator.auth.request(
                 method,
                 f"vehicles/{coordinator.vehicle_id}{subpath}",
+                version=version,
                 json=payload,
             ),
             logger=_LOGGER,

--- a/custom_components/smartcar/errors.py
+++ b/custom_components/smartcar/errors.py
@@ -5,10 +5,6 @@ class EmptyVehicleListError(HomeAssistantError):
     """Error to indicate no vehicles were returned by the API."""
 
 
-class MissingVINError(HomeAssistantError):
-    """Error to indicate a vehicle has no VIN."""
-
-
 class UnsupportedUserConfigurationError(HomeAssistantError):
     """Error to indicate multiple users are linked to a Smartcar application."""
 

--- a/custom_components/smartcar/errors.py
+++ b/custom_components/smartcar/errors.py
@@ -9,5 +9,9 @@ class MissingVINError(HomeAssistantError):
     """Error to indicate a vehicle has no VIN."""
 
 
+class UnsupportedUserConfigurationError(HomeAssistantError):
+    """Error to indicate multiple users are linked to a Smartcar application."""
+
+
 class InvalidAuthError(HomeAssistantError):
     """Error to indicate there is invalid auth."""

--- a/custom_components/smartcar/lock.py
+++ b/custom_components/smartcar/lock.py
@@ -58,7 +58,15 @@ class SmartcarDoorLock(SmartcarEntity[bool, bool], LockEntity):
         self,
         **kwargs,  # noqa: ARG002, ANN003
     ) -> None:
-        if await self._async_send_command("/security", {"action": "LOCK"}):
+        version = self.coordinator.auth.version
+        command = "/security/lock"
+        payload = None
+
+        if version == "v2":
+            command = "/security"
+            payload = {"action": "LOCK"}
+
+        if await self._async_send_command(command, payload):
             self._inject_raw_value(value=True)
             self.async_write_ha_state()
 
@@ -66,6 +74,14 @@ class SmartcarDoorLock(SmartcarEntity[bool, bool], LockEntity):
         self,
         **kwargs,  # noqa: ARG002, ANN003
     ) -> None:
-        if await self._async_send_command("/security", {"action": "UNLOCK"}):
+        version = self.coordinator.auth.version
+        command = "/security/unlock"
+        payload = None
+
+        if version == "v2":
+            command = "/security"
+            payload = {"action": "UNLOCK"}
+
+        if await self._async_send_command(command, payload):
             self._inject_raw_value(value=False)
             self.async_write_ha_state()

--- a/custom_components/smartcar/number.py
+++ b/custom_components/smartcar/number.py
@@ -33,7 +33,7 @@ ENTITY_DESCRIPTIONS: tuple[NumberEntityDescription, ...] = (
             (
                 round(value["limit"] * 100)
                 for value in values or []
-                if value["type"].lower() == "global" and value["condition"] is None
+                if value["type"].lower() == "global" and value.get("condition") is None
             ),
             None,
         ),

--- a/custom_components/smartcar/number.py
+++ b/custom_components/smartcar/number.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import logging
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from homeassistant.components.number import (
     NumberEntity,
@@ -86,9 +86,16 @@ class SmartcarChargeLimitNumber(
         assert value >= 50, "Value must be between 50 and 100"
         assert value <= 100, "Value must be between 50 and 100"
 
-        if await self._async_send_command(
-            "/charge/limit", {"limit": (raw_value := value / 100.0)}
-        ):
+        version = self.coordinator.auth.version
+        raw_value = value / 100.0
+        command = "/charge/set-limit"
+        payload: dict[str, Any] = {"data": {"attributes": {"percent": value}}}
+
+        if version == "v2":
+            command = "/charge/limit"
+            payload = {"limit": (raw_value := value / 100.0)}
+
+        if await self._async_send_command(command, payload):
             non_global_or_conditional_limits = [
                 value
                 for value in self._extract_raw_value() or []

--- a/custom_components/smartcar/sensor.py
+++ b/custom_components/smartcar/sensor.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfPressure,
     UnitOfSpeed,
+    UnitOfTemperature,
     UnitOfTime,
     UnitOfVolume,
 )
@@ -50,6 +51,43 @@ from .entity import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _diag_status(body: object) -> object:
+    """Extract a diagnostic system status string from a webhook signal body.
+
+    Field name is inferred from Smartcar conventions; falls back across the
+    likely keys so it keeps working once real data flows for this vehicle.
+
+    Returns:
+        The extracted status or the body unchanged.
+    """
+    if not isinstance(body, dict):
+        return body
+    return body.get("status") or body.get("value")
+
+
+def _dtc_count(body: object) -> object:
+    if not isinstance(body, dict):
+        return body
+    value = body.get("value")
+    return body.get("count") if value is None else value
+
+
+def _dtc_list(body: object) -> object:
+    if not isinstance(body, dict):
+        return body
+    items = body.get("value") or body.get("values") or body.get("codes") or []
+    if not isinstance(items, list):
+        return str(items)
+    codes = [str(i.get("code", i)) if isinstance(i, dict) else str(i) for i in items]
+    return ", ".join(codes) if codes else "none"
+
+
+def _hvac_number(body: object) -> object:
+    if not isinstance(body, dict):
+        return body
+    return body.get("value")
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -326,6 +364,83 @@ SENSOR_TYPES: tuple[SmartcarSensorDescription, ...] = (
         name="Firmware Version",
         value_key_path="connectivitysoftware-currentfirmwareversion.value",
         icon="mdi:chip",
+    ),
+    # --- Diagnostics (read_diagnostics) ---
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_ABS,
+        name="ABS Status",
+        value_key_path="diagnostics-abs",
+        value_cast=_diag_status,
+        icon="mdi:car-brake-abs",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_MIL,
+        name="Malfunction Indicator Lamp",
+        value_key_path="diagnostics-mil",
+        value_cast=_diag_status,
+        icon="mdi:engine",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_DTC_COUNT,
+        name="Trouble Code Count",
+        value_key_path="diagnostics-dtccount",
+        value_cast=_dtc_count,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:alert-circle",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_DTC_LIST,
+        name="Trouble Codes",
+        value_key_path="diagnostics-dtclist",
+        value_cast=_dtc_list,
+        icon="mdi:format-list-bulleted",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_EV_BATTERY_CONDITIONING,
+        name="EV Battery Conditioning Status",
+        value_key_path="diagnostics-evbatteryconditioning",
+        value_cast=_diag_status,
+        icon="mdi:battery-heart-variant",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_EV_CHARGING,
+        name="EV Charging Status",
+        value_key_path="diagnostics-evcharging",
+        value_cast=_diag_status,
+        icon="mdi:ev-station",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_EV_DRIVE_UNIT,
+        name="EV Drive Unit Status",
+        value_key_path="diagnostics-evdriveunit",
+        value_cast=_diag_status,
+        icon="mdi:cog",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_EV_HV_BATTERY,
+        name="EV High Voltage Battery Status",
+        value_key_path="diagnostics-evhvbattery",
+        value_cast=_diag_status,
+        icon="mdi:car-battery",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # --- Climate status (read_climate) ---
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.CABIN_TARGET_TEMPERATURE,
+        name="Cabin Target Temperature",
+        value_key_path="hvac-cabintargettemperature",
+        value_cast=_hvac_number,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        icon="mdi:thermostat",
     ),
 )
 

--- a/custom_components/smartcar/sensor.py
+++ b/custom_components/smartcar/sensor.py
@@ -357,7 +357,7 @@ async def async_setup_entry(  # noqa: RUF029
         entry.runtime_data.coordinators
     )
     meta_coordinator = entry.runtime_data.meta_coordinator
-    _LOGGER.debug("Setting up sensors for VINs: %s", list(coordinators.keys()))
+    _LOGGER.debug("Setting up sensors for vehicles: %s", list(coordinators.keys()))
     entities = [
         SmartcarSensor(coordinator, description)
         for coordinator in coordinators.values()
@@ -367,10 +367,20 @@ async def async_setup_entry(  # noqa: RUF029
         SmartcarMetaSensor(
             meta_coordinator,
             description,
-            {"identifiers": {(DOMAIN, vehicle_coordinator.vin)}},
+            {"identifiers": {(DOMAIN, device_id)}},
         )
         for vehicle_coordinator in coordinators.values()
         for description in META_SENSOR_TYPES
+        if (
+            vehicle_coordinator.version == "v3"
+            and (device_id := vehicle_coordinator.vehicle_id)
+        )
+        or (
+            vehicle_coordinator.version == "v2"
+            and (
+                device_id := (vehicle_coordinator.vin or vehicle_coordinator.vehicle_id)
+            )
+        )
     ]
     _LOGGER.info("Adding %s Smartcar sensor entities", len(entities))
     async_add_entities(entities)
@@ -403,10 +413,10 @@ class SmartcarMetaSensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntity)
         """Initialize."""
         super().__init__(coordinator)
 
-        (_, vin) = next(iter(device_info["identifiers"]))
+        (_, device_id) = next(iter(device_info["identifiers"]))
 
         self.entity_description = description
-        self._attr_unique_id = f"{vin}_{description.key}"
+        self._attr_unique_id = f"{device_id}_{description.key}"
         self._attr_device_info = device_info
 
     @property

--- a/custom_components/smartcar/services.py
+++ b/custom_components/smartcar/services.py
@@ -87,9 +87,20 @@ async def _send_security_command(
         )
 
     if not vin:
-        vin = next(iter(entry.runtime_data.coordinators.keys()))
+        vin = next(
+            iter(
+                coordinator.vin
+                for coordinator in entry.runtime_data.coordinators.values()
+            )
+        )
 
-    coordinator = entry.runtime_data.coordinators[vin]
+    coordinator = next(
+        iter(
+            coordinator
+            for coordinator in entry.runtime_data.coordinators.values()
+            if coordinator.vin == vin
+        )
+    )
     description = next(
         description
         for description in LOCK_ENTITY_DESCRIPTIONS

--- a/custom_components/smartcar/services.py
+++ b/custom_components/smartcar/services.py
@@ -96,7 +96,15 @@ async def _send_security_command(
         if description.key == EntityDescriptionKey.DOOR_LOCK
     )
 
-    if await async_send_command(coordinator, "/security", {"action": action}):
+    version = coordinator.auth.version
+    command = f"/security/{action.lower()}"
+    payload = None
+
+    if version == "v2":
+        command = "/security"
+        payload = {"action": action}
+
+    if await async_send_command(coordinator, command, payload):
         inject_raw_value(coordinator, description, value=action == "LOCK")
 
         entities: list[er.RegistryEntry] = er.async_entries_for_config_entry(

--- a/custom_components/smartcar/switch.py
+++ b/custom_components/smartcar/switch.py
@@ -13,6 +13,17 @@ from .entity import SmartcarEntity, SmartcarEntityDescription
 _LOGGER = logging.getLogger(__name__)
 
 
+def _hvac_bool(body: object) -> object:
+    """Extract a boolean from an HVAC webhook signal body ({"value": bool}).
+
+    Returns:
+        The extracted boolean or the body unchanged.
+    """
+    if isinstance(body, dict):
+        return body.get("value")
+    return body
+
+
 @dataclass(frozen=True, kw_only=True)
 class SmartcarSwitchDescription(SwitchEntityDescription, SmartcarEntityDescription):
     """Class describing Smartcar switch entities."""
@@ -27,6 +38,16 @@ ENTITY_DESCRIPTIONS: tuple[SwitchEntityDescription, ...] = (
     ),
 )
 
+CLIMATE_ENTITY_DESCRIPTIONS: tuple[SwitchEntityDescription, ...] = (
+    SmartcarSwitchDescription(
+        key=EntityDescriptionKey.CLIMATE,
+        name="Climate",
+        value_key_path="hvac-iscabinhvacactive",
+        value_cast=_hvac_bool,
+        icon="mdi:air-conditioner",
+    ),
+)
+
 
 async def async_setup_entry(  # noqa: RUF029
     hass: HomeAssistant,  # noqa: ARG001
@@ -37,10 +58,16 @@ async def async_setup_entry(  # noqa: RUF029
     coordinators: dict[str, SmartcarVehicleCoordinator] = (
         entry.runtime_data.coordinators
     )
-    entities = [
+    entities: list[SwitchEntity] = [
         SmartcarChargingSwitch(coordinator, description)
         for coordinator in coordinators.values()
         for description in ENTITY_DESCRIPTIONS
+        if coordinator.is_scope_enabled(description.key, verbose=True)
+    ]
+    entities += [
+        SmartcarClimateSwitch(coordinator, description)
+        for coordinator in coordinators.values()
+        for description in CLIMATE_ENTITY_DESCRIPTIONS
         if coordinator.is_scope_enabled(description.key, verbose=True)
     ]
     _LOGGER.info("Adding %s Smartcar switch entities", len(entities))
@@ -82,6 +109,48 @@ class SmartcarChargingSwitch(SmartcarEntity[bool, bool], SwitchEntity):
 
         if version == "v2":
             command = "/charge"
+            payload = {"action": "STOP"}
+
+        if await self._async_send_command(command, payload):
+            self._inject_raw_value(value=False)
+            self.async_write_ha_state()
+
+
+class SmartcarClimateSwitch(SmartcarEntity[bool, bool], SwitchEntity):
+    """Switch entity to start/stop cabin climate (preconditioning)."""
+
+    _attr_has_entity_name = True
+
+    @property
+    def is_on(self) -> bool:
+        return self._extract_value()
+
+    async def async_turn_on(
+        self,
+        **kwargs,  # noqa: ARG002, ANN003
+    ) -> None:
+        version = self.coordinator.auth.version
+        command = "/climate/start"
+        payload = None
+
+        if version == "v2":
+            command = "/climate"
+            payload = {"action": "START"}
+
+        if await self._async_send_command(command, payload):
+            self._inject_raw_value(value=True)
+            self.async_write_ha_state()
+
+    async def async_turn_off(
+        self,
+        **kwargs,  # noqa: ARG002, ANN003
+    ) -> None:
+        version = self.coordinator.auth.version
+        command = "/climate/stop"
+        payload = None
+
+        if version == "v2":
+            command = "/climate"
             payload = {"action": "STOP"}
 
         if await self._async_send_command(command, payload):

--- a/custom_components/smartcar/switch.py
+++ b/custom_components/smartcar/switch.py
@@ -60,7 +60,15 @@ class SmartcarChargingSwitch(SmartcarEntity[bool, bool], SwitchEntity):
         self,
         **kwargs,  # noqa: ARG002, ANN003
     ) -> None:
-        if await self._async_send_command("/charge", {"action": "START"}):
+        version = self.coordinator.auth.version
+        command = "/charge/start"
+        payload = None
+
+        if version == "v2":
+            command = "/charge"
+            payload = {"action": "START"}
+
+        if await self._async_send_command(command, payload):
             self._inject_raw_value(value=True)
             self.async_write_ha_state()
 
@@ -68,6 +76,14 @@ class SmartcarChargingSwitch(SmartcarEntity[bool, bool], SwitchEntity):
         self,
         **kwargs,  # noqa: ARG002, ANN003
     ) -> None:
-        if await self._async_send_command("/charge", {"action": "STOP"}):
+        version = self.coordinator.auth.version
+        command = "/charge/stop"
+        payload = None
+
+        if version == "v2":
+            command = "/charge"
+            payload = {"action": "STOP"}
+
+        if await self._async_send_command(command, payload):
             self._inject_raw_value(value=False)
             self.async_write_ha_state()

--- a/custom_components/smartcar/translations/en.json
+++ b/custom_components/smartcar/translations/en.json
@@ -21,6 +21,7 @@
       "oauth_timeout": "Timeout resolving OAuth token.",
       "oauth_unauthorized": "OAuth authorization error while obtaining access token.",
       "reauth_successful": "Re-authentication was successful",
+      "reconfigure_successful": "Reconfiguration was successful",
       "unknown": "Unexpected error",
       "user_rejected_authorize": "Account linking rejected: {error}",
       "wrong_vehicles": "The vehicles must match the original selections. Choose the vehicles with VIN(s): {vins}."

--- a/custom_components/smartcar/translations/en.json
+++ b/custom_components/smartcar/translations/en.json
@@ -1,124 +1,132 @@
 {
-    "application_credentials": {
-        "description": "Follow the [instructions]({more_info_url}) to configure Smartcar for your vehicle:\n\n1. Go to [Applications]({oauth_creds_url}) and your application from the list.\n1. Choose **Configuration** from the side menu.\n1. Copy the **Client ID**.\n1. Regenerate and copy the the **Client Secret**.\n1. Add `{redirect_url}` under *Authorized redirect URI*."
+  "application_credentials": {
+    "description": "Follow the [instructions]({more_info_url}) to configure Smartcar for your vehicle:\n\n1. Go to [Applications]({oauth_creds_url}) and your application from the list.\n1. Choose **Configuration** from the side menu.\n1. Copy the **Client ID**.\n1. Regenerate and copy the the **Client Secret**.\n1. Add `{redirect_url}` under *Authorized redirect URI*."
+  },
+  "config": {
+    "abort": {
+      "already_configured": "Account is already configured",
+      "already_in_progress": "Configuration flow is already in progress",
+      "authorize_url_timeout": "Timeout generating authorize URL.",
+      "cannot_connect": "Failed to connect",
+      "cloud_not_connected": "Not connected to Home Assistant Cloud.",
+      "duplicate_vehicles": "Vehicles may only be set up once. The following VINs {vins} are already configured.",
+      "invalid_access_token": "Invalid access token",
+      "missing_configuration": "The component is not configured. Please follow the documentation.",
+      "missing_credentials": "The integration requires application credentials.",
+      "no_url_available": "No URL available. For information about this error, [check the help section]({docs_url})",
+      "no_vehicles": "No vehicles were available to setup.",
+      "not_single_user_app": "Application must have only a single user connected.",
+      "oauth_error": "Received invalid token data.",
+      "oauth_failed": "Error while obtaining access token.",
+      "oauth_timeout": "Timeout resolving OAuth token.",
+      "oauth_unauthorized": "OAuth authorization error while obtaining access token.",
+      "reauth_successful": "Re-authentication was successful",
+      "unknown": "Unexpected error",
+      "user_rejected_authorize": "Account linking rejected: {error}",
+      "wrong_vehicles": "The vehicles must match the original selections. Choose the vehicles with VIN(s): {vins}."
     },
-    "config": {
-        "abort": {
-            "already_configured": "Account is already configured",
-            "already_in_progress": "Configuration flow is already in progress",
-            "authorize_url_timeout": "Timeout generating authorize URL.",
-            "cannot_connect": "Failed to connect",
-            "cloud_not_connected": "Not connected to Home Assistant Cloud.",
-            "duplicate_vehicles": "Vehicles may only be set up once. The following VINs {vins} are already configured.",
-            "invalid_access_token": "Invalid access token",
-            "missing_configuration": "The component is not configured. Please follow the documentation.",
-            "missing_credentials": "The integration requires application credentials.",
-            "no_url_available": "No URL available. For information about this error, [check the help section]({docs_url})",
-            "no_vehicles": "No vehicles were available to setup.",
-            "oauth_error": "Received invalid token data.",
-            "oauth_failed": "Error while obtaining access token.",
-            "oauth_timeout": "Timeout resolving OAuth token.",
-            "oauth_unauthorized": "OAuth authorization error while obtaining access token.",
-            "reauth_successful": "Re-authentication was successful",
-            "unknown": "Unexpected error",
-            "user_rejected_authorize": "Account linking rejected: {error}",
-            "wrong_vehicles": "The vehicles must match the original selections. Choose the vehicles with VIN(s): {vins}."
-        },
-        "create_entry": {
-            "default": "To send events to Home Assistant, you will need to set up a [webhook with Smartcar]({smartcar_url}). Use the following URL:\n\n`{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details."
-        },
-        "error": {
-            "no_scopes": "At least one scope needs to be selected",
-            "no_management_token": "Missing application management token",
-            "extraneous_management_token": "Do not provide application management token unless using webhooks"
-        },
-        "step": {
-            "pick_implementation": {
-                "title": "Pick authentication method"
-            },
-            "reauth_confirm": {
-                "description": "The Smartcar integration needs to re-authenticate your account",
-                "title": "Authentication expired for {name}"
-            },
-            "webhooks": {
-                "data": {
-                    "use_webhooks": "Use webhooks",
-                    "application_management_token": "Token: only provide if using webhooks"
-                },
-                "description": "Provide your _Application Management Token_ from your [Smartcar account]({smartcar_url}) to use webhooks.\n\nSee [the documentation]({docs_url}) for further details.",
-                "title": "Smartcar configuration"
-            },
-            "scopes": {
-                "data": {
-                    "control_charge": "Control charging (start/stop & target charge)",
-                    "control_security": "Lock or unlock vehicle",
-                    "read_battery": "Get EV/PHEV battery level, capacity & current range",
-                    "read_charge": "Get details on whether the car is plugged in and charging",
-                    "read_engine_oil": "Get engine oil health",
-                    "read_fuel": "Get fuel tank level",
-                    "read_location": "Get the vehicle's location",
-                    "read_odometer": "Get total distance traveled",
-                    "read_security": "Get details on whether doors, windows & more are enabled",
-                    "read_tires": "Get tire pressure details"
-                },
-                "description": "Select the permissions you would like to grant",
-                "title": "Permission selection"
-            }
-        }
+    "create_entry": {
+      "default": "To send events to Home Assistant, you will need to set up a [webhook with Smartcar]({smartcar_url}). Use the following URL:\n\n`{webhook_url}`\n\nSee [the documentation]({docs_url}) for further details."
     },
-    "exceptions": {
-        "batch_update_error": {
-            "message": "An error occurred while retrieving vehicle state from the Smartcar API: {error}"
-        }
+    "error": {
+      "no_application_id": "Missing application ID",
+      "no_scopes": "At least one scope needs to be selected",
+      "no_management_token": "Missing application management token",
+      "extraneous_management_token": "Do not provide application management token unless using webhooks"
     },
-    "options": {
-        "abort": {
-            "cloud_not_connected": "Not connected to Home Assistant Cloud.",
-            "unknown": "Unexpected error"
+    "step": {
+      "pick_implementation": {
+        "title": "Pick authentication method"
+      },
+      "reauth_confirm": {
+        "description": "The Smartcar integration needs to re-authenticate your account",
+        "title": "Authentication expired for {name}"
+      },
+      "webhooks": {
+        "data": {
+          "application_id": "Application ID",
+          "application_management_token": "Application Management Token",
+          "use_webhooks": "Use webhooks"
         },
-        "error": {
-            "no_management_token": "Missing application management token",
-            "extraneous_management_token": "Do not provide application management token unless using webhooks"
+        "data_description": {
+          "application_id": "Required for new Smartcar accounts and for v3.",
+          "application_management_token": "Only provide if using webhooks. This is the _Application Management Token_ from your [Smartcar account]({smartcar_url}) to use webhooks.\n\nSee [the documentation]({docs_url}) for further details.",
+          "use_webhooks": "Webhooks are Smartcar's preferred data update delivery method."
         },
-        "step": {
-            "webhooks": {
-                "data": {
-                    "use_webhooks": "Use webhooks",
-                    "application_management_token": "Token: only provide if using webhooks"
-                },
-                "description": "Provide your _Application Management Token_ from your [Smartcar account]({smartcar_url}) to use webhooks.\n\nTo send events to Home Assistant, you will need to set up a [webhook with Smartcar]({smartcar_url}). Use the following URL:\n\n`{webhook_url}`\n\nIf the above URL indicates that webhooks are not enabled, revisit this configuration screen after completing the setup to get the URL.\n\nSee [the documentation]({docs_url}) for further details.",
-                "title": "Smartcar configuration"
-            }
-        }
-    },
-    "services": {
-        "lock_doors": {
-            "description": "Lock doors for a vehicle.",
-            "fields": {
-                "config_entry": {
-                    "description": "The config entry to use for this service.",
-                    "name": "Config entry"
-                },
-                "vin": {
-                    "description": "The VIN of the vehicle to target.",
-                    "name": "VIN"
-                }
-            },
-            "name": "Lock doors"
+        "description": "To configure Smartcar, provide an _Application ID_. An _Application Management Token_ is also required if enabling webhooks.",
+        "title": "Smartcar configuration"
+      },
+      "scopes": {
+        "data": {
+          "control_charge": "Control charging (start/stop & target charge)",
+          "control_security": "Lock or unlock vehicle",
+          "read_battery": "Get EV/PHEV battery level, capacity & current range",
+          "read_charge": "Get details on whether the car is plugged in and charging",
+          "read_engine_oil": "Get engine oil health",
+          "read_fuel": "Get fuel tank level",
+          "read_location": "Get the vehicle's location",
+          "read_odometer": "Get total distance traveled",
+          "read_security": "Get details on whether doors, windows & more are enabled",
+          "read_tires": "Get tire pressure details"
         },
-        "unlock_doors": {
-            "description": "Unlock doors for a vehicle.",
-            "fields": {
-                "config_entry": {
-                    "description": "The config entry to use for this service.",
-                    "name": "Config entry"
-                },
-                "vin": {
-                    "description": "The VIN of the vehicle to target.",
-                    "name": "VIN"
-                }
-            },
-            "name": "Unlock doors"
-        }
+        "description": "Select the permissions you would like to grant",
+        "title": "Permission selection"
+      }
     }
+  },
+  "exceptions": {
+    "batch_update_error": {
+      "message": "An error occurred while retrieving vehicle state from the Smartcar API: {error}"
+    }
+  },
+  "options": {
+    "abort": {
+      "cloud_not_connected": "Not connected to Home Assistant Cloud.",
+      "unknown": "Unexpected error"
+    },
+    "error": {
+      "no_management_token": "Missing application management token",
+      "extraneous_management_token": "Do not provide application management token unless using webhooks"
+    },
+    "step": {
+      "webhooks": {
+        "data": {
+          "use_webhooks": "Use webhooks",
+          "application_management_token": "Token: only provide if using webhooks"
+        },
+        "description": "Provide your _Application Management Token_ from your [Smartcar account]({smartcar_url}) to use webhooks.\n\nTo send events to Home Assistant, you will need to set up a [webhook with Smartcar]({smartcar_url}). Use the following URL:\n\n`{webhook_url}`\n\nIf the above URL indicates that webhooks are not enabled, revisit this configuration screen after completing the setup to get the URL.\n\nSee [the documentation]({docs_url}) for further details.",
+        "title": "Smartcar configuration"
+      }
+    }
+  },
+  "services": {
+    "lock_doors": {
+      "description": "Lock doors for a vehicle.",
+      "fields": {
+        "config_entry": {
+          "description": "The config entry to use for this service.",
+          "name": "Config entry"
+        },
+        "vin": {
+          "description": "The VIN of the vehicle to target.",
+          "name": "VIN"
+        }
+      },
+      "name": "Lock doors"
+    },
+    "unlock_doors": {
+      "description": "Unlock doors for a vehicle.",
+      "fields": {
+        "config_entry": {
+          "description": "The config entry to use for this service.",
+          "name": "Config entry"
+        },
+        "vin": {
+          "description": "The VIN of the vehicle to target.",
+          "name": "VIN"
+        }
+      },
+      "name": "Unlock doors"
+    }
+  }
 }

--- a/custom_components/smartcar/translations/en.json
+++ b/custom_components/smartcar/translations/en.json
@@ -85,7 +85,7 @@
       "fix_flow": {
         "step": {
           "confirm": {
-            "description": "{title} is using deprecated Smartcar v2 API. To migrate to v3.0:\n - Remove all Smartcar integrations that use v2 (this is required for the next step).\n- Remove all _Application Credentials_ that use a v2 `client_id`. To be safe, you can remove all Smartcar credentials from the _Application Credentials_.\n- Re-setup each smart car integration, ensuring that you use the new v3 _API credentials_ and _Application ID_ rather than _Legacy Credentials_.\n\nRead the documentation for more information.",
+            "description": "{title} is using deprecated Smartcar v2 API. To migrate to v3.0:\n - Remove all Smartcar integrations that use v2. _Note: this is required for the next step._\n- Remove all _Application Credentials_ that use a v2 `client_id`. To be safe, you can remove all Smartcar credentials from the _Application Credentials_.\n- Re-setup each smart car integration, ensuring that you use the new v3 _API credentials_ and _Application ID_ rather than _Legacy Credentials_.\n\nRead the [documentation]({docs_url}) for more information.",
             "title": "Smartcar v2 API deprecated"
           }
         }

--- a/custom_components/smartcar/translations/en.json
+++ b/custom_components/smartcar/translations/en.json
@@ -79,6 +79,19 @@
       "message": "An error occurred while retrieving vehicle state from the Smartcar API: {error}"
     }
   },
+  "issues": {
+    "legacy_client_id": {
+      "title": "Smartcar v2 API deprecated",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "description": "{title} is using deprecated Smartcar v2 API. To migrate to v3.0:\n - Remove all Smartcar integrations that use v2 (this is required for the next step).\n- Remove all _Application Credentials_ that use a v2 `client_id`. To be safe, you can remove all Smartcar credentials from the _Application Credentials_.\n- Re-setup each smart car integration, ensuring that you use the new v3 _API credentials_ and _Application ID_ rather than _Legacy Credentials_.\n\nRead the documentation for more information.",
+            "title": "Smartcar v2 API deprecated"
+          }
+        }
+      }
+    }
+  },
   "options": {
     "abort": {
       "cloud_not_connected": "Not connected to Home Assistant Cloud.",

--- a/custom_components/smartcar/types.py
+++ b/custom_components/smartcar/types.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .auth import AbstractAuth
-
 if TYPE_CHECKING:
+    from .auth import AbstractAuth
     from .coordinator import SmartcarVehicleCoordinator
+
+
+type APIVersion = Literal["v2", "v3"]
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/custom_components/smartcar/util.py
+++ b/custom_components/smartcar/util.py
@@ -81,7 +81,15 @@ def unique_id_from_entry_data(data: dict) -> str:
 
 
 def vins_from_entry_data(data: dict) -> str:
-    return " ".join(sorted([vehicle["vin"] for vehicle in data["vehicles"].values()]))
+    return " ".join(
+        sorted(
+            [
+                vehicle["vin"]
+                for vehicle in data["vehicles"].values()
+                if vehicle.get("vin")
+            ]
+        )
+    )
 
 
 def hmac_sha256_hexdigest(key: str, msg: str) -> str:

--- a/custom_components/smartcar/util.py
+++ b/custom_components/smartcar/util.py
@@ -4,9 +4,12 @@ from functools import reduce
 import hashlib
 import hmac
 import logging
+import re
 from typing import Any, cast, overload
 
 from aiohttp import ClientResponse
+
+from .types import APIVersion
 
 _RETRYABLE_STATUSES = frozenset({429, 500})
 
@@ -65,6 +68,12 @@ async def async_request_with_retry(
 
     # unreachable — the loop always returns — but satisfies the type checker
     raise AssertionError  # pragma: no cover
+
+
+def api_version_for_client_id(client_id: str) -> APIVersion:
+    if re.match(r"^client_", client_id):
+        return "v3"
+    return "v2"
 
 
 def unique_id_from_entry_data(data: dict) -> str:

--- a/custom_components/smartcar/webhooks.py
+++ b/custom_components/smartcar/webhooks.py
@@ -1,11 +1,10 @@
 from collections.abc import Callable
-import copy
 from functools import wraps
 import hmac
 from http import HTTPStatus
 import json
 import logging
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 from aiohttp import web
 from homeassistant.components import cloud, webhook
@@ -15,19 +14,10 @@ from homeassistant.util import dt as dt_util
 
 from . import util
 from .const import CONF_APPLICATION_MANAGEMENT_TOKEN
-from .coordinator import DATAPOINT_CODE_MAP, SmartcarVehicleCoordinator
+from .coordinator import SmartcarVehicleCoordinator, _is_integrated
 from .types import SmartcarData
 
 _LOGGER = logging.getLogger(__name__)
-
-# values from the smartcar service that denote an imperial measurement and can
-# be converted by one of the imperial_conversion functions defined on an entity
-# description.
-_IMPERIAL_MEASUREMENTS = {"miles", "psi", "gallons"}
-
-_SIGNAL_BODY_MULTIVALUE_ITEM_KEY_MAP: dict[str | None, str] = {
-    "charge-chargelimits": "limit",
-}
 
 
 async def webhook_url_from_id(hass: HomeAssistant, webhook_id: str) -> tuple[str, bool]:
@@ -205,92 +195,13 @@ def _handle_webhook_errors(
             _LOGGER.debug("ignoring error in webhook: %s", error)
 
 
-def _is_integrated(signal: dict) -> bool:
-    code: str | None = signal.get("code")
-    return code in DATAPOINT_CODE_MAP
-
-
 def _handle_webhook_signals(
     coordinator: SmartcarVehicleCoordinator,
     signals: list[dict],
 ) -> None:
     with coordinator.create_updated_data() as (add, updated_data):
-        data_changed = False
-
         for signal in signals:
-            name: str | None = signal.get("name")
-            status = signal.get("status", {})
-            is_error = status.get("value") == "ERROR"
-            code: str | None = signal.get("code")
-            body = copy.deepcopy(signal.get("body", {}))
-            meta = signal.get("meta", {})
+            add.from_signal_attributes(signal)
 
-            if is_error:
-                _handle_webhook_signal_error(
-                    name,
-                    status.get("error", {}),
-                    level="error" if _is_integrated(signal) else "debug",
-                )
-
-                body = {"value": None}
-
-            if body.get("unit") == "percent":
-                _handle_percent_unit_conversion(code, body)
-
-            if code in DATAPOINT_CODE_MAP:
-                assert code is not None
-
-                data_age = meta.get("oemUpdatedAt") if not is_error else None
-                fetched_at = meta.get("retrievedAt") if not is_error else None
-                unit = body.pop("unit", None)
-                unit_system = (
-                    "imperial"
-                    if unit in _IMPERIAL_MEASUREMENTS
-                    else "metric"
-                    if unit
-                    else None
-                )
-
-                if data_age:
-                    data_age = dt_util.utc_from_timestamp(data_age / 1000)
-                if fetched_at:
-                    fetched_at = dt_util.utc_from_timestamp(fetched_at / 1000)
-
-                add.from_response_body(
-                    code,
-                    body=body,
-                    unit_system=unit_system,
-                    data_age=data_age,
-                    fetched_at=fetched_at,
-                    can_clear_meta=not is_error,
-                )
-
-                data_changed = True
-
-        if data_changed:
+        if add.addition_made:
             coordinator.async_set_updated_data(updated_data)
-
-
-def _handle_percent_unit_conversion(code: str | None, body: dict[str, Any]) -> None:
-    if "values" in body:
-        item_key = _SIGNAL_BODY_MULTIVALUE_ITEM_KEY_MAP.get(code) or "value"
-        values = body["values"]
-        values = [value | {item_key: value[item_key] / 100} for value in values]
-        body["values"] = values
-        body.pop("unit")
-    else:
-        body["value"] /= 100
-        body.pop("unit")
-
-
-def _handle_webhook_signal_error(
-    signal_name: str | None,
-    error: dict,
-    *,
-    level: Literal["error", "debug"] = "error",
-) -> None:
-    error_type = error.get("type")
-    error_code = error.get("code")
-
-    logger_method = getattr(_LOGGER, level)
-    logger_method("error for signal %s: %s:%s", signal_name, error_type, error_code)

--- a/custom_components/smartcar/webhooks.py
+++ b/custom_components/smartcar/webhooks.py
@@ -149,7 +149,9 @@ async def handle_webhook(
         ),
         None,
     )
-    coordinator = coordinators.get(vehicle_vin) if vehicle_vin else None
+    coordinator = coordinators.get(vehicle_id) or (
+        coordinators.get(vehicle_vin) if vehicle_vin else None
+    )
 
     if not coordinator:
         _LOGGER.debug(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -42,9 +42,14 @@ def aioclient_mock_append_vehicle_request(
     api_response_type: str,
     vehicle_fixture: str,
     vehicle_attributes: dict,
+    client_id_version: APIVersion,
 ):
     vehicle_id = vehicle_attributes["id"]
-    fixture_name = f"api/{vehicle_fixture}.{api_response_type}.json"
+    fixture_name = (
+        "api/"
+        f"{vehicle_fixture}.{api_response_type}"
+        f"{'.v3' if client_id_version == 'v3' else ''}.json"
+    )
     http_calls = load_json_array_fixture(fixture_name, DOMAIN)
 
     for http_call in http_calls:
@@ -77,7 +82,7 @@ def aioclient_mock_append_vehicle_request(
                 raise side_effect_class()
 
         getattr(aioclient_mock, method)(
-            f"{MOCK_API_ENDPOINT_LEGACY}{path}",
+            f"{MOCK_API_ENDPOINTS[client_id_version]}{path}",
             params=params,
             status=status,
             side_effect=side_effect,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,8 +11,14 @@ from pytest_homeassistant_custom_component.common import (
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 
 from custom_components.smartcar.const import DOMAIN
+from custom_components.smartcar.types import APIVersion
 
-MOCK_API_ENDPOINT = "http://test.local"
+MOCK_API_ENDPOINT = "http://test.local/v3"
+MOCK_API_ENDPOINT_LEGACY = "http://test.local/v2.0"
+MOCK_API_ENDPOINTS: dict[APIVersion, str] = {
+    "v2": MOCK_API_ENDPOINT_LEGACY,
+    "v3": MOCK_API_ENDPOINT,
+}
 MOCK_UTC_NOW = dt.datetime(2026, 2, 17, 16, 21, 32, 3842, tzinfo=dt.UTC)
 
 
@@ -43,7 +49,6 @@ def aioclient_mock_append_vehicle_request(
 
     for http_call in http_calls:
         method = http_call.get("method", "get")
-        version = http_call.get("version", "2.0")
         params = http_call.get("params", {})
         status = http_call.get("status", 200)
         side_effect = http_call.get("side_effect")
@@ -72,7 +77,7 @@ def aioclient_mock_append_vehicle_request(
                 raise side_effect_class()
 
         getattr(aioclient_mock, method)(
-            f"{MOCK_API_ENDPOINT}/v{version}{path}",
+            f"{MOCK_API_ENDPOINT_LEGACY}{path}",
             params=params,
             status=status,
             side_effect=side_effect,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,7 +224,8 @@ async def setup_credentials(
     client_id = None
     if client_id_version == "v2":
         client_id = "mock-id"
-    if client_id_version == "v3":
+    else:
+        assert client_id_version == "v3"
         client_id = "client_mock-id"
 
     if "no_credentials" in request.keywords:
@@ -275,6 +276,7 @@ def vehicle(
     api_response_type: str,
     vehicle_fixture: str,
     vehicle_attributes: dict,
+    client_id_version: APIVersion,
 ) -> dict:
     """Return a specific vehicle."""
 
@@ -283,6 +285,7 @@ def vehicle(
         api_response_type,
         vehicle_fixture,
         vehicle_attributes,
+        client_id_version,
     )
 
     return dict(vehicle_attributes, _api=http_calls)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -409,6 +409,7 @@ def webhook_scenario(
     platform: str,
     vehicle_fixture: str,
     vehicle_attributes: dict,
+    client_id_version: APIVersion,
     webhook_body: str,
     webhook_headers: dict[str, Any],
     expected: dict[str, Any],
@@ -468,7 +469,11 @@ def webhook_scenario(
         assert aioclient_mock.call_count == expected_calls
         assert mock_start_reauth.call_count == expected_reauth_calls
 
-        device_id = vehicle_attributes["vin"]
+        device_id = (
+            vehicle_attributes["vin"]
+            if client_id_version == "v2"
+            else vehicle_attributes["id"]
+        )
         device = device_registry.async_get_device({(DOMAIN, device_id)})
         entities = entity_registry.entities.get_entries_for_device_id(device.id)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,10 @@ from homeassistant.components.application_credentials import (
 from homeassistant.const import CONF_WEBHOOK_ID, CONTENT_TYPE_JSON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
+from homeassistant.helpers.config_entry_oauth2_flow import (
+    OAuth2Session,
+    LocalOAuth2Implementation,
+)
 from homeassistant.setup import async_setup_component
 import pytest
 from pytest_homeassistant_custom_component.common import (
@@ -35,6 +38,7 @@ from syrupy.assertion import SnapshotAssertion
 from .syrupy import SmartcarSnapshotExtension
 from . import MOCK_UTC_NOW
 from custom_components.smartcar import util
+from custom_components.smartcar.types import APIVersion
 
 from custom_components.smartcar.auth import AbstractAuth
 from custom_components.smartcar.const import (
@@ -45,7 +49,7 @@ from custom_components.smartcar.const import (
 )
 
 from . import (
-    MOCK_API_ENDPOINT,
+    MOCK_API_ENDPOINTS,
     aioclient_mock_append_vehicle_request,
     setup_added_integration,
     setup_integration,
@@ -162,10 +166,19 @@ def mock_smartcar_auth(
         def __init__(
             self,
             websession: ClientSession,
-            oauth_session: OAuth2Session,
-            host: str,
+            implementation: LocalOAuth2Implementation = None,
+            oauth_session: OAuth2Session = None,
+            *,
+            version: APIVersion,
+            user_id: str | None = None,
         ) -> None:
-            super().__init__(websession, host)
+            super().__init__(
+                websession,
+                MOCK_API_ENDPOINTS,
+                version=version,
+                user_id=user_id,
+            )
+            self._oauth_impl = implementation
             self._oauth_session = oauth_session
 
         async def async_get_access_token(self) -> str:
@@ -179,21 +192,21 @@ def mock_smartcar_auth(
         ) as mock_auth,
         patch(
             "custom_components.smartcar.AsyncConfigEntryAuth",
-            new=lambda session, oauth, _host: MockAuth(
-                session, oauth, MOCK_API_ENDPOINT
+            new=lambda session, impl, oauth, _endpoint, **kwargs: MockAuth(
+                session,
+                impl,
+                oauth,
+                version=util.api_version_for_client_id(impl.client_id),
+                **kwargs,
             ),
         ),
         patch(
             "custom_components.smartcar.AccessTokenAuthImpl",
-            new=lambda session, _token, _host: MockAuth(
-                session, None, MOCK_API_ENDPOINT
-            ),
+            new=lambda session, *_args, **kwargs: MockAuth(session, **kwargs),
         ),
         patch(
             "custom_components.smartcar.config_flow.AccessTokenAuthImpl",
-            new=lambda session, _token, _host: MockAuth(
-                session, None, MOCK_API_ENDPOINT
-            ),
+            new=lambda session, *_args, **kwargs: MockAuth(session, **kwargs),
         ),
     ):
         yield mock_auth.return_value
@@ -201,10 +214,18 @@ def mock_smartcar_auth(
 
 @pytest.fixture(autouse=True)
 async def setup_credentials(
-    request: pytest.FixtureRequest, hass: HomeAssistant
+    request: pytest.FixtureRequest,
+    hass: HomeAssistant,
+    client_id_version: APIVersion,
 ) -> None:
     """Fixture to setup credentials."""
     assert await async_setup_component(hass, "application_credentials", {})
+
+    client_id = None
+    if client_id_version == "v2":
+        client_id = "mock-id"
+    if client_id_version == "v3":
+        client_id = "client_mock-id"
 
     if "no_credentials" in request.keywords:
         pass
@@ -212,7 +233,7 @@ async def setup_credentials(
         await async_import_client_credential(
             hass,
             DOMAIN,
-            ClientCredential("mock-id", "mock-secret"),
+            ClientCredential(client_id, "mock-secret"),
             DOMAIN,
         )
 
@@ -221,6 +242,12 @@ async def setup_credentials(
 def mock_api_response_type() -> str:
     """Fixture to define the API response fixture to use."""
     return "ok"
+
+
+@pytest.fixture(name="client_id_version")
+def mock_client_id_version() -> APIVersion:
+    """Fixture to define the client id version to use."""
+    return "v2"
 
 
 @pytest.fixture(name="enabled_scopes")

--- a/tests/fixtures/api/get_vin_signal.json
+++ b/tests/fixtures/api/get_vin_signal.json
@@ -1,0 +1,39 @@
+{
+  "data": {
+    "id": "vehicleidentification-vin",
+    "type": "signal",
+    "attributes": {
+      "code": "vehicleidentification-vin",
+      "name": "VIN",
+      "group": "VehicleIdentification",
+      "status": {
+        "value": "SUCCESS"
+      },
+      "body": {
+        "value": "5YJSA1CN5DFP00101"
+      }
+    },
+    "meta": {
+      "ingestedAt": "2026-06-24T03:52:17.940Z"
+    },
+    "links": {
+      "self": "https://vehicle.api.smartcar.com/v3/vehicles/36ab27d0-fd9d-4455-823a-ce30af709ffc/signals/vehicleidentification-vin"
+    }
+  },
+  "included": {
+    "vehicle": {
+      "id": "36ab27d0-fd9d-4455-823a-ce30af709ffc",
+      "type": "vehicle",
+      "attributes": {
+        "make": "TESLA",
+        "model": "Model S",
+        "year": 2014,
+        "powertrainType": "BEV",
+        "mode": "live"
+      },
+      "links": {
+        "self": "https://vehicle.api.smartcar.com/v3/vehicles/36ab27d0-fd9d-4455-823a-ce30af709ffc"
+      }
+    }
+  }
+}

--- a/tests/fixtures/api/get_vin_signal_missing.json
+++ b/tests/fixtures/api/get_vin_signal_missing.json
@@ -1,0 +1,45 @@
+{
+  "data": {
+    "id": "vehicleidentification-vin",
+    "type": "signal",
+    "attributes": {
+      "code": "vehicleidentification-vin",
+      "name": "VIN",
+      "group": "VehicleIdentification",
+
+      "status": {
+        "value": "ERROR",
+        "error": {
+          "type": "COMPATIBILITY",
+          "code": "VEHICLE_NOT_CAPABLE",
+          "title": "Vehicle Not Capable",
+          "detail": "The vehicle is incapable of performing your request.",
+          "description": "Mock description: Not ingested.",
+          "resolution": { "type": "UNKNOWN_RESOLUTION_TYPE" }
+        }
+      },
+      "body": {
+        "value": null
+      }
+    },
+    "links": {
+      "self": "https://vehicle.api.smartcar.com/v3/vehicles/36ab27d0-fd9d-4455-823a-ce30af709ffc/signals/vehicleidentification-vin"
+    }
+  },
+  "included": {
+    "vehicle": {
+      "id": "36ab27d0-fd9d-4455-823a-ce30af709ffc",
+      "type": "vehicle",
+      "attributes": {
+        "make": "TESLA",
+        "model": "Model S",
+        "year": 2014,
+        "powertrainType": "BEV",
+        "mode": "live"
+      },
+      "links": {
+        "self": "https://vehicle.api.smartcar.com/v3/vehicles/36ab27d0-fd9d-4455-823a-ce30af709ffc"
+      }
+    }
+  }
+}

--- a/tests/fixtures/api/list_connections.json
+++ b/tests/fixtures/api/list_connections.json
@@ -1,0 +1,68 @@
+{
+  "data": [
+    {
+      "id": "553c49e4-08b0-4d28-b83c-fe9d539af4aa",
+      "type": "connection",
+      "attributes": {
+        "permissions": [
+          "control_charge",
+          "read_battery",
+          "read_charge",
+          "read_location",
+          "read_odometer",
+          "read_security",
+          "read_vehicle_info",
+          "read_vin"
+        ],
+        "vehicle": {
+          "make": "TESLA",
+          "model": "Model S",
+          "year": 2014,
+          "mode": "live",
+          "powertrainType": "BEV"
+        },
+        "user": {
+          "id": "218eda3b-0656-49a8-8f3d-360cdad07334"
+        }
+      },
+      "relationships": {
+        "vehicle": {
+          "data": {
+            "id": "36ab27d0-fd9d-4455-823a-ce30af709ffc",
+            "type": "vehicle"
+          },
+          "links": {
+            "related": "https://vehicle.api.smartcar.com/v3/vehicles/36ab27d0-fd9d-4455-823a-ce30af709ffc"
+          }
+        },
+        "user": {
+          "data": {
+            "id": "218eda3b-0656-49a8-8f3d-360cdad07334",
+            "type": "user"
+          }
+        }
+      },
+      "meta": {
+        "createdAt": "2025-05-03T02:45:45.349Z",
+        "updatedAt": "2026-06-21T02:56:21.130Z"
+      },
+      "links": {
+        "self": "https://vehicle.api.smartcar.com/v3/connections/553c49e4-08b0-4d28-b83c-fe9d539af4aa"
+      }
+    }
+  ],
+  "meta": {
+    "pageNumber": 1,
+    "pageSize": 10,
+    "totalCount": 1,
+    "orderBy": "createdAt",
+    "orderDirection": "DESC"
+  },
+  "links": {
+    "self": "https://vehicle.api.smartcar.com/v3/connections?page%5Bnumber%5D=1&page%5Bsize%5D=10&filter%5Bvehicle.mode%5D=live",
+    "first": "https://vehicle.api.smartcar.com/v3/connections?page%5Bnumber%5D=1&page%5Bsize%5D=10&filter%5Bvehicle.mode%5D=live",
+    "last": "https://vehicle.api.smartcar.com/v3/connections?page%5Bnumber%5D=1&page%5Bsize%5D=10&filter%5Bvehicle.mode%5D=live",
+    "next": null,
+    "prev": null
+  }
+}

--- a/tests/fixtures/api/list_connections_empty.json
+++ b/tests/fixtures/api/list_connections_empty.json
@@ -1,0 +1,17 @@
+{
+  "data": [],
+  "meta": {
+    "pageNumber": 1,
+    "pageSize": 0,
+    "totalCount": 0,
+    "orderBy": "createdAt",
+    "orderDirection": "DESC"
+  },
+  "links": {
+    "self": "https://vehicle.api.smartcar.com/v3/connections?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "first": "https://vehicle.api.smartcar.com/v3/connections?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "https://vehicle.api.smartcar.com/v3/connections?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "next": null,
+    "prev": null
+  }
+}

--- a/tests/fixtures/api/list_connections_with_multiple_users.json
+++ b/tests/fixtures/api/list_connections_with_multiple_users.json
@@ -1,0 +1,118 @@
+{
+  "data": [
+    {
+      "id": "553c49e4-08b0-4d28-b83c-fe9d539af4aa",
+      "type": "connection",
+      "attributes": {
+        "permissions": [
+          "control_charge",
+          "read_battery",
+          "read_charge",
+          "read_location",
+          "read_odometer",
+          "read_security",
+          "read_vehicle_info",
+          "read_vin"
+        ],
+        "vehicle": {
+          "make": "TESLA",
+          "model": "Model S",
+          "year": 2014,
+          "mode": "live",
+          "powertrainType": "BEV"
+        },
+        "user": {
+          "id": "218eda3b-0656-49a8-8f3d-360cdad07334"
+        }
+      },
+      "relationships": {
+        "vehicle": {
+          "data": {
+            "id": "36ab27d0-fd9d-4455-823a-ce30af709ffc",
+            "type": "vehicle"
+          },
+          "links": {
+            "related": "https://vehicle.api.smartcar.com/v3/vehicles/36ab27d0-fd9d-4455-823a-ce30af709ffc"
+          }
+        },
+        "user": {
+          "data": {
+            "id": "218eda3b-0656-49a8-8f3d-360cdad07334",
+            "type": "user"
+          }
+        }
+      },
+      "meta": {
+        "createdAt": "2025-05-03T02:45:45.349Z",
+        "updatedAt": "2026-06-21T02:56:21.130Z"
+      },
+      "links": {
+        "self": "https://vehicle.api.smartcar.com/v3/connections/553c49e4-08b0-4d28-b83c-fe9d539af4aa"
+      }
+    },
+    {
+      "id": "55eca09c-8a93-43e7-92eb-21ffdca4e15d",
+      "type": "connection",
+      "attributes": {
+        "permissions": [
+          "control_charge",
+          "read_battery",
+          "read_charge",
+          "read_location",
+          "read_odometer",
+          "read_security",
+          "read_vehicle_info",
+          "read_vin"
+        ],
+        "vehicle": {
+          "make": "BYD",
+          "model": "Seal U Dm-i",
+          "year": 2025,
+          "mode": "live",
+          "powertrainType": "BEV"
+        },
+        "user": {
+          "id": "d24686bb-8cda-42bc-832b-c894efd64d84"
+        }
+      },
+      "relationships": {
+        "vehicle": {
+          "data": {
+            "id": "b3014ded-85db-4f12-8923-7a231354d8d0",
+            "type": "vehicle"
+          },
+          "links": {
+            "related": "https://vehicle.api.smartcar.com/v3/vehicles/b3014ded-85db-4f12-8923-7a231354d8d0"
+          }
+        },
+        "user": {
+          "data": {
+            "id": "d24686bb-8cda-42bc-832b-c894efd64d84",
+            "type": "user"
+          }
+        }
+      },
+      "meta": {
+        "createdAt": "2025-05-03T02:45:45.349Z",
+        "updatedAt": "2026-06-21T02:56:21.130Z"
+      },
+      "links": {
+        "self": "https://vehicle.api.smartcar.com/v3/connections/55eca09c-8a93-43e7-92eb-21ffdca4e15d"
+      }
+    }
+  ],
+  "meta": {
+    "pageNumber": 1,
+    "pageSize": 10,
+    "totalCount": 2,
+    "orderBy": "createdAt",
+    "orderDirection": "DESC"
+  },
+  "links": {
+    "self": "https://vehicle.api.smartcar.com/v3/connections?page%5Bnumber%5D=1&page%5Bsize%5D=10&filter%5Bvehicle.mode%5D=live",
+    "first": "https://vehicle.api.smartcar.com/v3/connections?page%5Bnumber%5D=1&page%5Bsize%5D=10&filter%5Bvehicle.mode%5D=live",
+    "last": "https://vehicle.api.smartcar.com/v3/connections?page%5Bnumber%5D=1&page%5Bsize%5D=10&filter%5Bvehicle.mode%5D=live",
+    "next": null,
+    "prev": null
+  }
+}

--- a/tests/fixtures/api/unknown_make.ok.v3.json
+++ b/tests/fixtures/api/unknown_make.ok.v3.json
@@ -1,0 +1,365 @@
+[
+  {
+    "method": "get",
+    "vehicle_path": "/signals",
+    "params": {},
+    "response": {
+      "data": [
+        {
+          "id": "charge-chargelimits",
+          "type": "signal",
+          "attributes": {
+            "code": "charge-chargelimits",
+            "name": "ChargeLimits",
+            "group": "Charge",
+            "status": { "value": "SUCCESS" },
+            "body": {
+              "values": [{ "type": "GLOBAL", "limit": 80 }],
+              "activeLimit": 80,
+              "unit": "percent"
+            }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.743Z",
+            "oemUpdatedAt": "2026-06-29T23:55:53.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/charge-chargelimits"
+          }
+        },
+        {
+          "id": "charge-detailedchargingstatus",
+          "type": "signal",
+          "attributes": {
+            "code": "charge-detailedchargingstatus",
+            "name": "DetailedChargingStatus",
+            "group": "Charge",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": "FULLY_CHARGED" }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.743Z",
+            "oemUpdatedAt": "2026-06-29T23:55:53.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/charge-detailedchargingstatus"
+          }
+        },
+        {
+          "id": "charge-ischarging",
+          "type": "signal",
+          "attributes": {
+            "code": "charge-ischarging",
+            "name": "IsCharging",
+            "group": "Charge",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": false }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.743Z",
+            "oemUpdatedAt": "2026-06-29T23:55:53.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/charge-ischarging"
+          }
+        },
+        {
+          "id": "charge-ischargingcableconnected",
+          "type": "signal",
+          "attributes": {
+            "code": "charge-ischargingcableconnected",
+            "name": "IsChargingCableConnected",
+            "group": "Charge",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": true }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.743Z",
+            "oemUpdatedAt": "2026-06-29T23:55:53.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/charge-ischargingcableconnected"
+          }
+        },
+        {
+          "id": "charge-ischargingcablelatched",
+          "type": "signal",
+          "attributes": {
+            "code": "charge-ischargingcablelatched",
+            "name": "IsChargingCableLatched",
+            "group": "Charge",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": true }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.743Z",
+            "oemUpdatedAt": "2026-06-29T23:55:53.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/charge-ischargingcablelatched"
+          }
+        },
+        {
+          "id": "closure-doors",
+          "type": "signal",
+          "attributes": {
+            "code": "closure-doors",
+            "name": "Doors",
+            "group": "Closure",
+            "status": { "value": "SUCCESS" },
+            "body": {
+              "values": [
+                { "row": 0, "column": 0, "isOpen": false, "isLocked": true },
+                { "row": 0, "column": 1, "isOpen": true, "isLocked": true },
+                { "row": 1, "column": 0, "isOpen": false, "isLocked": true },
+                { "row": 1, "column": 1, "isOpen": false, "isLocked": true }
+              ],
+              "rowCount": 2,
+              "columnCount": 2
+            }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.557Z",
+            "oemUpdatedAt": "2026-06-29T23:46:50.695Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/closure-doors"
+          }
+        },
+        {
+          "id": "closure-enginecover",
+          "type": "signal",
+          "attributes": {
+            "code": "closure-enginecover",
+            "name": "EngineCover",
+            "group": "Closure",
+            "status": { "value": "SUCCESS" },
+            "body": { "isOpen": false }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.557Z",
+            "oemUpdatedAt": "2026-06-29T23:46:50.695Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/closure-enginecover"
+          }
+        },
+        {
+          "id": "closure-islocked",
+          "type": "signal",
+          "attributes": {
+            "code": "closure-islocked",
+            "name": "IsLocked",
+            "group": "Closure",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": false }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.557Z",
+            "oemUpdatedAt": "2026-06-29T23:46:50.695Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/closure-islocked"
+          }
+        },
+        {
+          "id": "closure-reartrunk",
+          "type": "signal",
+          "attributes": {
+            "code": "closure-reartrunk",
+            "name": "RearTrunk",
+            "group": "Closure",
+            "status": { "value": "SUCCESS" },
+            "body": { "isOpen": false, "isLocked": true }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.557Z",
+            "oemUpdatedAt": "2026-06-29T23:46:50.695Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/closure-reartrunk"
+          }
+        },
+        {
+          "id": "closure-sunroof",
+          "type": "signal",
+          "attributes": {
+            "code": "closure-sunroof",
+            "name": "Sunroof",
+            "group": "Closure",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "COMPATIBILITY",
+                "code": "VEHICLE_NOT_CAPABLE",
+                "title": "Vehicle Not Capable",
+                "detail": "The vehicle is incapable of performing your request.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "UNKNOWN_RESOLUTION_TYPE" }
+              }
+            },
+            "body": { "isOpen": null }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-04T15:45:55.333Z",
+            "oemUpdatedAt": "2026-06-04T15:26:19.203Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/closure-sunroof"
+          }
+        },
+        {
+          "id": "closure-windows",
+          "type": "signal",
+          "attributes": {
+            "code": "closure-windows",
+            "name": "Windows",
+            "group": "Closure",
+            "status": { "value": "SUCCESS" },
+            "body": {
+              "values": [
+                { "row": 0, "column": 0, "isOpen": false },
+                { "row": 0, "column": 1, "isOpen": false },
+                { "row": 1, "column": 0, "isOpen": false },
+                { "row": 1, "column": 1, "isOpen": false }
+              ],
+              "rowCount": 2,
+              "columnCount": 2
+            }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.557Z",
+            "oemUpdatedAt": "2026-06-29T23:46:50.695Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/closure-windows"
+          }
+        },
+        {
+          "id": "internalcombustionengine-fuellevel",
+          "type": "signal",
+          "attributes": {
+            "code": "internalcombustionengine-fuellevel",
+            "name": "FuelLevel",
+            "group": "InternalCombustionEngine",
+            "body": { "value": 0.3 },
+            "meta": {
+              "oemUpdatedAt": 1758238233000,
+              "retrievedAt": 1758238783086
+            }
+          },
+          "meta": { "ingestedAt": "2026-06-30T00:03:55.110Z" },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/internalcombustionengine-fuellevel"
+          }
+        },
+        {
+          "id": "internalcombustionengine-oillife",
+          "type": "signal",
+          "attributes": {
+            "code": "internalcombustionengine-oillife",
+            "name": "OilLife",
+            "group": "InternalCombustionEngine",
+            "body": { "value": 0.35, "unit": "percent" },
+            "meta": {
+              "oemUpdatedAt": 1758238233000,
+              "retrievedAt": 1758238783086
+            }
+          },
+          "meta": { "ingestedAt": "2026-06-30T00:03:55.110Z" },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/internalcombustionengine-range"
+          }
+        },
+        {
+          "id": "location-preciselocation",
+          "type": "signal",
+          "attributes": {
+            "code": "location-preciselocation",
+            "name": "PreciseLocation",
+            "group": "Location",
+            "status": { "value": "SUCCESS" },
+            "body": {
+              "latitude": 37.4292,
+              "longitude": 122.1381,
+              "locationType": "LAST_PARKED"
+            }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.557Z",
+            "oemUpdatedAt": "2026-06-29T23:46:50.695Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/location-preciselocation"
+          }
+        },
+        {
+          "id": "odometer-traveleddistance",
+          "type": "signal",
+          "attributes": {
+            "code": "odometer-traveleddistance",
+            "name": "TraveledDistance",
+            "group": "Odometer",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": 37829, "unit": "km" }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.557Z",
+            "oemUpdatedAt": "2026-06-29T23:46:50.695Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/odometer-traveleddistance"
+          }
+        },
+        {
+          "id": "tractionbattery-stateofcharge",
+          "type": "signal",
+          "attributes": {
+            "code": "tractionbattery-stateofcharge",
+            "name": "StateOfCharge",
+            "group": "TractionBattery",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": 30, "unit": "percent" }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.743Z",
+            "oemUpdatedAt": "2026-06-29T23:55:53.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/tractionbattery-stateofcharge"
+          }
+        }
+      ],
+      "meta": { "totalCount": 16, "pageSize": 16, "pageNumber": 1 },
+      "links": {
+        "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals"
+      },
+      "included": {
+        "vehicle": {
+          "id": "a1d50709-3502-4faa-ba43-a5c7565e6a09",
+          "type": "vehicle",
+          "attributes": {
+            "mode": "live"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09"
+          }
+        }
+      }
+    }
+  }
+]

--- a/tests/fixtures/api/vw_id_4.ok.v3.json
+++ b/tests/fixtures/api/vw_id_4.ok.v3.json
@@ -1,0 +1,742 @@
+[
+  {
+    "method": "get",
+    "vehicle_path": "/signals",
+    "params": {},
+    "response": {
+      "data": [
+        {
+          "id": "charge-chargelimits",
+          "type": "signal",
+          "attributes": {
+            "code": "charge-chargelimits",
+            "name": "ChargeLimits",
+            "group": "Charge",
+            "status": { "value": "SUCCESS" },
+            "body": {
+              "values": [{ "type": "GLOBAL", "limit": 80 }],
+              "activeLimit": 80,
+              "unit": "percent"
+            }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.743Z",
+            "oemUpdatedAt": "2026-06-29T23:55:53.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/charge-chargelimits"
+          }
+        },
+        {
+          "id": "charge-chargerate",
+          "type": "signal",
+          "attributes": {
+            "code": "charge-chargerate",
+            "name": "ChargeRate",
+            "group": "Charge",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "VEHICLE_STATE",
+                "code": "NOT_CHARGING",
+                "title": "Not Charging",
+                "detail": "The vehicle is unable to perform your request because it is not currently charging.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "UNKNOWN_RESOLUTION_TYPE" }
+              }
+            },
+            "body": { "value": 53, "unit": "km/h" }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-29T03:57:53.614Z",
+            "oemUpdatedAt": "2026-06-29T03:55:47.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/charge-chargerate"
+          }
+        },
+        {
+          "id": "charge-chargingconnectortype",
+          "type": "signal",
+          "attributes": {
+            "code": "charge-chargingconnectortype",
+            "name": "ChargingConnectorType",
+            "group": "Charge",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": "invalid" }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.743Z",
+            "oemUpdatedAt": "2026-06-29T23:55:53.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/charge-chargingconnectortype"
+          }
+        },
+        {
+          "id": "charge-detailedchargingstatus",
+          "type": "signal",
+          "attributes": {
+            "code": "charge-detailedchargingstatus",
+            "name": "DetailedChargingStatus",
+            "group": "Charge",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": "NOT_CHARGING" }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.743Z",
+            "oemUpdatedAt": "2026-06-29T23:55:53.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/charge-detailedchargingstatus"
+          }
+        },
+        {
+          "id": "charge-ischarging",
+          "type": "signal",
+          "attributes": {
+            "code": "charge-ischarging",
+            "name": "IsCharging",
+            "group": "Charge",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": false }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.743Z",
+            "oemUpdatedAt": "2026-06-29T23:55:53.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/charge-ischarging"
+          }
+        },
+        {
+          "id": "charge-ischargingcableconnected",
+          "type": "signal",
+          "attributes": {
+            "code": "charge-ischargingcableconnected",
+            "name": "IsChargingCableConnected",
+            "group": "Charge",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": false }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.743Z",
+            "oemUpdatedAt": "2026-06-29T23:55:53.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/charge-ischargingcableconnected"
+          }
+        },
+        {
+          "id": "charge-ischargingcablelatched",
+          "type": "signal",
+          "attributes": {
+            "code": "charge-ischargingcablelatched",
+            "name": "IsChargingCableLatched",
+            "group": "Charge",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": false }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.743Z",
+            "oemUpdatedAt": "2026-06-29T23:55:53.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/charge-ischargingcablelatched"
+          }
+        },
+        {
+          "id": "charge-timetocomplete",
+          "type": "signal",
+          "attributes": {
+            "code": "charge-timetocomplete",
+            "name": "TimeToComplete",
+            "group": "Charge",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "VEHICLE_STATE",
+                "code": "NOT_CHARGING",
+                "title": "Not Charging",
+                "detail": "The vehicle is unable to perform your request because it is not currently charging.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "UNKNOWN_RESOLUTION_TYPE" }
+              }
+            },
+            "body": { "value": 5 }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-29T03:57:53.614Z",
+            "oemUpdatedAt": "2026-06-29T03:55:47.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/charge-timetocomplete"
+          }
+        },
+        {
+          "id": "charge-wattage",
+          "type": "signal",
+          "attributes": {
+            "code": "charge-wattage",
+            "name": "Wattage",
+            "group": "Charge",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "VEHICLE_STATE",
+                "code": "NOT_CHARGING",
+                "title": "Not Charging",
+                "detail": "The vehicle is unable to perform your request because it is not currently charging.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "UNKNOWN_RESOLUTION_TYPE" }
+              }
+            },
+            "body": { "value": 8000, "unit": "watts" }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-29T03:57:53.614Z",
+            "oemUpdatedAt": "2026-06-29T03:55:47.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/charge-wattage"
+          }
+        },
+        {
+          "id": "closure-doors",
+          "type": "signal",
+          "attributes": {
+            "code": "closure-doors",
+            "name": "Doors",
+            "group": "Closure",
+            "status": { "value": "SUCCESS" },
+            "body": {
+              "values": [
+                { "row": 0, "column": 0, "isOpen": false, "isLocked": true },
+                { "row": 0, "column": 1, "isOpen": false, "isLocked": true },
+                { "row": 1, "column": 0, "isOpen": false, "isLocked": true },
+                { "row": 1, "column": 1, "isOpen": false, "isLocked": true }
+              ],
+              "rowCount": 2,
+              "columnCount": 2
+            }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.557Z",
+            "oemUpdatedAt": "2026-06-29T23:46:50.695Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/closure-doors"
+          }
+        },
+        {
+          "id": "closure-enginecover",
+          "type": "signal",
+          "attributes": {
+            "code": "closure-enginecover",
+            "name": "EngineCover",
+            "group": "Closure",
+            "status": { "value": "SUCCESS" },
+            "body": { "isOpen": false }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.557Z",
+            "oemUpdatedAt": "2026-06-29T23:46:50.695Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/closure-enginecover"
+          }
+        },
+        {
+          "id": "closure-fronttrunk",
+          "type": "signal",
+          "attributes": {
+            "code": "closure-fronttrunk",
+            "name": "FrontTrunk",
+            "group": "Closure",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "PERMISSION",
+                "code": "UNKNOWN",
+                "title": "Unknown",
+                "detail": "Your application has insufficient permissions to access the requested resource. Please prompt the user to re-authenticate using Smartcar Connect.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "REAUTHENTICATE" }
+              }
+            }
+          },
+          "meta": { "ingestedAt": "2026-03-17T15:41:40.604Z" },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/closure-fronttrunk"
+          }
+        },
+        {
+          "id": "closure-islocked",
+          "type": "signal",
+          "attributes": {
+            "code": "closure-islocked",
+            "name": "IsLocked",
+            "group": "Closure",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": true }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.557Z",
+            "oemUpdatedAt": "2026-06-29T23:46:50.695Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/closure-islocked"
+          }
+        },
+        {
+          "id": "closure-reartrunk",
+          "type": "signal",
+          "attributes": {
+            "code": "closure-reartrunk",
+            "name": "RearTrunk",
+            "group": "Closure",
+            "status": { "value": "SUCCESS" },
+            "body": { "isOpen": false, "isLocked": true }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.557Z",
+            "oemUpdatedAt": "2026-06-29T23:46:50.695Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/closure-reartrunk"
+          }
+        },
+        {
+          "id": "closure-sunroof",
+          "type": "signal",
+          "attributes": {
+            "code": "closure-sunroof",
+            "name": "Sunroof",
+            "group": "Closure",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "COMPATIBILITY",
+                "code": "VEHICLE_NOT_CAPABLE",
+                "title": "Vehicle Not Capable",
+                "detail": "The vehicle is incapable of performing your request.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "UNKNOWN_RESOLUTION_TYPE" }
+              }
+            },
+            "body": { "isOpen": null }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-04T15:45:55.333Z",
+            "oemUpdatedAt": "2026-06-04T15:26:19.203Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/closure-sunroof"
+          }
+        },
+        {
+          "id": "closure-windows",
+          "type": "signal",
+          "attributes": {
+            "code": "closure-windows",
+            "name": "Windows",
+            "group": "Closure",
+            "status": { "value": "SUCCESS" },
+            "body": {
+              "values": [
+                { "row": 0, "column": 0, "isOpen": false },
+                { "row": 0, "column": 1, "isOpen": false },
+                { "row": 1, "column": 0, "isOpen": false },
+                { "row": 1, "column": 1, "isOpen": false }
+              ],
+              "rowCount": 2,
+              "columnCount": 2
+            }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.557Z",
+            "oemUpdatedAt": "2026-06-29T23:46:50.695Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/closure-windows"
+          }
+        },
+        {
+          "id": "connectivitysoftware-currentfirmwareversion",
+          "type": "signal",
+          "attributes": {
+            "code": "connectivitysoftware-currentfirmwareversion",
+            "name": "CurrentFirmwareVersion",
+            "group": "ConnectivitySoftware",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "COMPATIBILITY",
+                "code": "VEHICLE_NOT_CAPABLE",
+                "title": "Vehicle Not Capable",
+                "detail": "The vehicle is incapable of performing your request.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "UNKNOWN_RESOLUTION_TYPE" }
+              }
+            }
+          },
+          "meta": { "ingestedAt": "2026-06-30T00:03:55.110Z" },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/connectivitysoftware-currentfirmwareversion"
+          }
+        },
+        {
+          "id": "connectivitystatus-isasleep",
+          "type": "signal",
+          "attributes": {
+            "code": "connectivitystatus-isasleep",
+            "name": "IsAsleep",
+            "group": "ConnectivityStatus",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "COMPATIBILITY",
+                "code": "VEHICLE_NOT_CAPABLE",
+                "title": "Vehicle Not Capable",
+                "detail": "The vehicle is incapable of performing your request.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "UNKNOWN_RESOLUTION_TYPE" }
+              }
+            }
+          },
+          "meta": { "ingestedAt": "2026-06-30T00:03:55.110Z" },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/connectivitystatus-isasleep"
+          }
+        },
+        {
+          "id": "connectivitystatus-isdigitalkeypaired",
+          "type": "signal",
+          "attributes": {
+            "code": "connectivitystatus-isdigitalkeypaired",
+            "name": "IsDigitalKeyPaired",
+            "group": "ConnectivityStatus",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "COMPATIBILITY",
+                "code": "VEHICLE_NOT_CAPABLE",
+                "title": "Vehicle Not Capable",
+                "detail": "The vehicle is incapable of performing your request.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "UNKNOWN_RESOLUTION_TYPE" }
+              }
+            }
+          },
+          "meta": { "ingestedAt": "2026-06-30T00:03:55.110Z" },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/connectivitystatus-isdigitalkeypaired"
+          }
+        },
+        {
+          "id": "connectivitystatus-isonline",
+          "type": "signal",
+          "attributes": {
+            "code": "connectivitystatus-isonline",
+            "name": "IsOnline",
+            "group": "ConnectivityStatus",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "COMPATIBILITY",
+                "code": "VEHICLE_NOT_CAPABLE",
+                "title": "Vehicle Not Capable",
+                "detail": "The vehicle is incapable of performing your request.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "UNKNOWN_RESOLUTION_TYPE" }
+              }
+            }
+          },
+          "meta": { "ingestedAt": "2026-06-30T00:03:55.110Z" },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/connectivitystatus-isonline"
+          }
+        },
+        {
+          "id": "internalcombustionengine-amountremaining",
+          "type": "signal",
+          "attributes": {
+            "code": "internalcombustionengine-amountremaining",
+            "name": "AmountRemaining",
+            "group": "InternalCombustionEngine",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "COMPATIBILITY",
+                "code": "VEHICLE_NOT_CAPABLE",
+                "title": "Vehicle Not Capable",
+                "detail": "The vehicle is incapable of performing your request.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "UNKNOWN_RESOLUTION_TYPE" }
+              }
+            }
+          },
+          "meta": { "ingestedAt": "2026-06-30T00:03:55.110Z" },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/internalcombustionengine-amountremaining"
+          }
+        },
+        {
+          "id": "internalcombustionengine-fuellevel",
+          "type": "signal",
+          "attributes": {
+            "code": "internalcombustionengine-fuellevel",
+            "name": "FuelLevel",
+            "group": "InternalCombustionEngine",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "COMPATIBILITY",
+                "code": "VEHICLE_NOT_CAPABLE",
+                "title": "Vehicle Not Capable",
+                "detail": "The vehicle is incapable of performing your request.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "UNKNOWN_RESOLUTION_TYPE" }
+              }
+            }
+          },
+          "meta": { "ingestedAt": "2026-06-30T00:03:55.110Z" },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/internalcombustionengine-fuellevel"
+          }
+        },
+        {
+          "id": "internalcombustionengine-range",
+          "type": "signal",
+          "attributes": {
+            "code": "internalcombustionengine-range",
+            "name": "Range",
+            "group": "InternalCombustionEngine",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "PERMISSION",
+                "code": "UNKNOWN",
+                "title": "Unknown",
+                "detail": "Your application has insufficient permissions to access the requested resource. Please prompt the user to re-authenticate using Smartcar Connect.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "REAUTHENTICATE" }
+              }
+            }
+          },
+          "meta": { "ingestedAt": "2026-06-30T00:03:55.110Z" },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/internalcombustionengine-range"
+          }
+        },
+        {
+          "id": "location-preciselocation",
+          "type": "signal",
+          "attributes": {
+            "code": "location-preciselocation",
+            "name": "PreciseLocation",
+            "group": "Location",
+            "status": { "value": "SUCCESS" },
+            "body": {
+              "latitude": 37.4292,
+              "longitude": 122.1381,
+              "locationType": "LAST_PARKED"
+            }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.557Z",
+            "oemUpdatedAt": "2026-06-29T23:46:50.695Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/location-preciselocation"
+          }
+        },
+        {
+          "id": "odometer-traveleddistance",
+          "type": "signal",
+          "attributes": {
+            "code": "odometer-traveleddistance",
+            "name": "TraveledDistance",
+            "group": "Odometer",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": 52891, "unit": "km" }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.557Z",
+            "oemUpdatedAt": "2026-06-29T23:46:50.695Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/odometer-traveleddistance"
+          }
+        },
+        {
+          "id": "tractionbattery-range",
+          "type": "signal",
+          "attributes": {
+            "code": "tractionbattery-range",
+            "name": "Range",
+            "group": "TractionBattery",
+            "status": { "value": "SUCCESS" },
+            "body": {
+              "value": 253,
+              "type": "DEFAULT",
+              "additionalValues": [],
+              "unit": "km"
+            }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.743Z",
+            "oemUpdatedAt": "2026-06-29T23:55:53.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/tractionbattery-range"
+          }
+        },
+        {
+          "id": "tractionbattery-stateofcharge",
+          "type": "signal",
+          "attributes": {
+            "code": "tractionbattery-stateofcharge",
+            "name": "StateOfCharge",
+            "group": "TractionBattery",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": 57, "unit": "percent" }
+          },
+          "meta": {
+            "ingestedAt": "2026-06-30T00:03:55.110Z",
+            "retrievedAt": "2026-06-30T00:03:53.743Z",
+            "oemUpdatedAt": "2026-06-29T23:55:53.000Z"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/tractionbattery-stateofcharge"
+          }
+        },
+        {
+          "id": "vehicleidentification-nickname",
+          "type": "signal",
+          "attributes": {
+            "code": "vehicleidentification-nickname",
+            "name": "Nickname",
+            "group": "VehicleIdentification",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "COMPATIBILITY",
+                "code": "VEHICLE_NOT_CAPABLE",
+                "title": "Vehicle Not Capable",
+                "detail": "The vehicle is incapable of performing your request.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "UNKNOWN_RESOLUTION_TYPE" }
+              }
+            }
+          },
+          "meta": { "ingestedAt": "2026-06-30T00:03:55.110Z" },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/vehicleidentification-nickname"
+          }
+        },
+        {
+          "id": "vehicleidentification-vin",
+          "type": "signal",
+          "attributes": {
+            "code": "vehicleidentification-vin",
+            "name": "VIN",
+            "group": "VehicleIdentification",
+            "status": { "value": "SUCCESS" },
+            "body": { "value": "VIWP1AB29P15LA85784N" }
+          },
+          "meta": { "ingestedAt": "2026-06-30T00:03:55.110Z" },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/vehicleidentification-vin"
+          }
+        },
+        {
+          "id": "vehicleuseraccount-permissions",
+          "type": "signal",
+          "attributes": {
+            "code": "vehicleuseraccount-permissions",
+            "name": "Permissions",
+            "group": "VehicleUserAccount",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "COMPATIBILITY",
+                "code": "VEHICLE_NOT_CAPABLE",
+                "title": "Vehicle Not Capable",
+                "detail": "The vehicle is incapable of performing your request.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "UNKNOWN_RESOLUTION_TYPE" }
+              }
+            }
+          },
+          "meta": { "ingestedAt": "2026-06-30T00:03:55.110Z" },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/vehicleuseraccount-permissions"
+          }
+        },
+        {
+          "id": "vehicleuseraccount-role",
+          "type": "signal",
+          "attributes": {
+            "code": "vehicleuseraccount-role",
+            "name": "Role",
+            "group": "VehicleUserAccount",
+            "status": {
+              "value": "ERROR",
+              "error": {
+                "type": "COMPATIBILITY",
+                "code": "VEHICLE_NOT_CAPABLE",
+                "title": "Vehicle Not Capable",
+                "detail": "The vehicle is incapable of performing your request.",
+                "description": "Deprecated. Use detail",
+                "resolution": { "type": "UNKNOWN_RESOLUTION_TYPE" }
+              }
+            }
+          },
+          "meta": { "ingestedAt": "2026-06-30T00:03:55.110Z" },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals/vehicleuseraccount-role"
+          }
+        }
+      ],
+      "meta": { "totalCount": 31, "pageSize": 31, "pageNumber": 1 },
+      "links": {
+        "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/signals"
+      },
+      "included": {
+        "vehicle": {
+          "id": "a1d50709-3502-4faa-ba43-a5c7565e6a09",
+          "type": "vehicle",
+          "attributes": {
+            "make": "VOLKSWAGEN",
+            "model": "ID.4",
+            "year": 2023,
+            "powertrainType": "BEV",
+            "mode": "live"
+          },
+          "links": {
+            "self": "https://vehicle.api.smartcar.com/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09"
+          }
+        }
+      }
+    }
+  }
+]

--- a/tests/snapshots/test_binary_sensor.ambr
+++ b/tests/snapshots/test_binary_sensor.ambr
@@ -27,6 +27,21 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-binary_sensor][binary_sensor.byd_seal_u_dm_i_cabin_hvac_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'BYD Seal U Dm-i Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.byd_seal_u_dm_i_cabin_hvac_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-byd_seal-binary_sensor][binary_sensor.byd_seal_u_dm_i_charging_cable_plugged_in]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -204,6 +219,21 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-binary_sensor][binary_sensor.byd_seal_u_dm_i_front_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'BYD Seal U Dm-i Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.byd_seal_u_dm_i_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-byd_seal-binary_sensor][binary_sensor.byd_seal_u_dm_i_front_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -247,6 +277,21 @@
     'state': 'on',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-binary_sensor][binary_sensor.byd_seal_u_dm_i_rear_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'BYD Seal U Dm-i Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.byd_seal_u_dm_i_rear_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-byd_seal-binary_sensor][binary_sensor.byd_seal_u_dm_i_rear_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -269,6 +314,21 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.byd_seal_u_dm_i_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-binary_sensor][binary_sensor.byd_seal_u_dm_i_steering_wheel_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'BYD Seal U Dm-i Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.byd_seal_u_dm_i_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -378,6 +438,21 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.jaguar_i_pace_battery_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-binary_sensor][binary_sensor.jaguar_i_pace_cabin_hvac_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'JAGUAR I-PACE Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.jaguar_i_pace_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -579,6 +654,21 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-binary_sensor][binary_sensor.jaguar_i_pace_front_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'JAGUAR I-PACE Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.jaguar_i_pace_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-binary_sensor][binary_sensor.jaguar_i_pace_front_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -624,6 +714,21 @@
     'state': 'on',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-binary_sensor][binary_sensor.jaguar_i_pace_rear_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'JAGUAR I-PACE Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.jaguar_i_pace_rear_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-binary_sensor][binary_sensor.jaguar_i_pace_rear_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -654,6 +759,21 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-binary_sensor][binary_sensor.jaguar_i_pace_steering_wheel_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'JAGUAR I-PACE Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.jaguar_i_pace_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-binary_sensor][binary_sensor.jaguar_i_pace_sunroof]
@@ -769,6 +889,21 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.polestar_polestar_2_battery_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-binary_sensor][binary_sensor.polestar_polestar_2_cabin_hvac_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'POLESTAR Polestar 2 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.polestar_polestar_2_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -970,6 +1105,21 @@
     'state': 'off',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-binary_sensor][binary_sensor.polestar_polestar_2_front_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'POLESTAR Polestar 2 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.polestar_polestar_2_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-polestar_2-binary_sensor][binary_sensor.polestar_polestar_2_front_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1015,6 +1165,21 @@
     'state': 'on',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-binary_sensor][binary_sensor.polestar_polestar_2_rear_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'POLESTAR Polestar 2 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.polestar_polestar_2_rear_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-polestar_2-binary_sensor][binary_sensor.polestar_polestar_2_rear_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1045,6 +1210,21 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-binary_sensor][binary_sensor.polestar_polestar_2_steering_wheel_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'POLESTAR Polestar 2 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.polestar_polestar_2_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_webhook_update[vehicle_state_all-polestar_2-binary_sensor][binary_sensor.polestar_polestar_2_sunroof]
@@ -1158,6 +1338,21 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-binary_sensor][binary_sensor.vw_id_4_cabin_hvac_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1339,6 +1534,21 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-binary_sensor][binary_sensor.vw_id_4_front_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-vw_id_4-binary_sensor][binary_sensor.vw_id_4_front_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1380,6 +1590,21 @@
     'state': 'on',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-binary_sensor][binary_sensor.vw_id_4_rear_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-vw_id_4-binary_sensor][binary_sensor.vw_id_4_rear_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1402,6 +1627,21 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-binary_sensor][binary_sensor.vw_id_4_steering_wheel_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/snapshots/test_config_flow.ambr
+++ b/tests/snapshots/test_config_flow.ambr
@@ -370,6 +370,28 @@
   list([
   ])
 # ---
+# name: test_full_flow_v3_only[empty_connections-v3]
+  list([
+    tuple(
+      'POST',
+      URL('https://iam.smartcar.com/oauth2/token'),
+      dict({
+        'client_id': 'client_mock-id',
+        'client_secret': 'mock-secret',
+        'grant_type': 'client_credentials',
+      }),
+      None,
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v3/connections'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
 # name: test_full_flow_v3_only[invalid_user_configuration-v3]
   list([
     tuple(

--- a/tests/snapshots/test_config_flow.ambr
+++ b/tests/snapshots/test_config_flow.ambr
@@ -212,6 +212,77 @@
     ),
   ])
 # ---
+# name: test_full_flow[no_webhooks_missing_vin-v2]
+  list([
+    tuple(
+      'POST',
+      URL('https://auth.smartcar.com/oauth/token'),
+      dict({
+        'client_id': 'mock-id',
+        'client_secret': 'mock-secret',
+        'code': 'abcd',
+        'grant_type': 'authorization_code',
+        'redirect_uri': 'https://example.com/auth/external/callback',
+      }),
+      None,
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v2.0/vehicles'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v2.0/vehicles/36ab27d0-fd9d-4455-823a-ce30af709ffc/vin'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v2.0/vehicles/36ab27d0-fd9d-4455-823a-ce30af709ffc'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_full_flow[no_webhooks_missing_vin-v3]
+  list([
+    tuple(
+      'POST',
+      URL('https://iam.smartcar.com/oauth2/token'),
+      dict({
+        'client_id': 'client_mock-id',
+        'client_secret': 'mock-secret',
+        'grant_type': 'client_credentials',
+      }),
+      None,
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v3/connections'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v3/vehicles/36ab27d0-fd9d-4455-823a-ce30af709ffc/signals/vehicleidentification-vin'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+        'sc-user-id': '218eda3b-0656-49a8-8f3d-360cdad07334',
+      }),
+    ),
+  ])
+# ---
 # name: test_full_flow[webhooks-v2]
   list([
     tuple(

--- a/tests/snapshots/test_config_flow.ambr
+++ b/tests/snapshots/test_config_flow.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_full_flow[cloud_not_connected]
+# name: test_full_flow[cloud_not_connected-v2]
   list([
     tuple(
       'POST',
@@ -39,7 +39,38 @@
     ),
   ])
 # ---
-# name: test_full_flow[cloud_webhooks]
+# name: test_full_flow[cloud_not_connected-v3]
+  list([
+    tuple(
+      'POST',
+      URL('https://iam.smartcar.com/oauth2/token'),
+      dict({
+        'client_id': 'client_mock-id',
+        'client_secret': 'mock-secret',
+        'grant_type': 'client_credentials',
+      }),
+      None,
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v3/connections'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v3/vehicles/36ab27d0-fd9d-4455-823a-ce30af709ffc/signals/vehicleidentification-vin'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+        'sc-user-id': '218eda3b-0656-49a8-8f3d-360cdad07334',
+      }),
+    ),
+  ])
+# ---
+# name: test_full_flow[cloud_webhooks-v2]
   list([
     tuple(
       'POST',
@@ -79,7 +110,38 @@
     ),
   ])
 # ---
-# name: test_full_flow[no_webhooks]
+# name: test_full_flow[cloud_webhooks-v3]
+  list([
+    tuple(
+      'POST',
+      URL('https://iam.smartcar.com/oauth2/token'),
+      dict({
+        'client_id': 'client_mock-id',
+        'client_secret': 'mock-secret',
+        'grant_type': 'client_credentials',
+      }),
+      None,
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v3/connections'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v3/vehicles/36ab27d0-fd9d-4455-823a-ce30af709ffc/signals/vehicleidentification-vin'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+        'sc-user-id': '218eda3b-0656-49a8-8f3d-360cdad07334',
+      }),
+    ),
+  ])
+# ---
+# name: test_full_flow[no_webhooks-v2]
   list([
     tuple(
       'POST',
@@ -119,7 +181,38 @@
     ),
   ])
 # ---
-# name: test_full_flow[webhooks]
+# name: test_full_flow[no_webhooks-v3]
+  list([
+    tuple(
+      'POST',
+      URL('https://iam.smartcar.com/oauth2/token'),
+      dict({
+        'client_id': 'client_mock-id',
+        'client_secret': 'mock-secret',
+        'grant_type': 'client_credentials',
+      }),
+      None,
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v3/connections'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v3/vehicles/36ab27d0-fd9d-4455-823a-ce30af709ffc/signals/vehicleidentification-vin'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+        'sc-user-id': '218eda3b-0656-49a8-8f3d-360cdad07334',
+      }),
+    ),
+  ])
+# ---
+# name: test_full_flow[webhooks-v2]
   list([
     tuple(
       'POST',
@@ -159,11 +252,76 @@
     ),
   ])
 # ---
-# name: test_full_flow[webhooks_extraneous_token]
+# name: test_full_flow[webhooks-v3]
+  list([
+    tuple(
+      'POST',
+      URL('https://iam.smartcar.com/oauth2/token'),
+      dict({
+        'client_id': 'client_mock-id',
+        'client_secret': 'mock-secret',
+        'grant_type': 'client_credentials',
+      }),
+      None,
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v3/connections'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v3/vehicles/36ab27d0-fd9d-4455-823a-ce30af709ffc/signals/vehicleidentification-vin'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+        'sc-user-id': '218eda3b-0656-49a8-8f3d-360cdad07334',
+      }),
+    ),
+  ])
+# ---
+# name: test_full_flow[webhooks_extraneous_token-v2]
   list([
   ])
 # ---
-# name: test_full_flow[webhooks_missing_token]
+# name: test_full_flow[webhooks_extraneous_token-v3]
+  list([
+  ])
+# ---
+# name: test_full_flow[webhooks_missing_token-v2]
+  list([
+  ])
+# ---
+# name: test_full_flow[webhooks_missing_token-v3]
+  list([
+  ])
+# ---
+# name: test_full_flow_v3_only[invalid_user_configuration-v3]
+  list([
+    tuple(
+      'POST',
+      URL('https://iam.smartcar.com/oauth2/token'),
+      dict({
+        'client_id': 'client_mock-id',
+        'client_secret': 'mock-secret',
+        'grant_type': 'client_credentials',
+      }),
+      None,
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v3/connections'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_full_flow_v3_only[missing_application_id-v3]
   list([
   ])
 # ---

--- a/tests/snapshots/test_diagnostics.ambr
+++ b/tests/snapshots/test_diagnostics.ambr
@@ -2,7 +2,7 @@
 # name: test_entry_diagnostics[unknown_make]
   dict({
     'data': dict({
-      'VIWP1AB29P15LA85784N': dict({
+      'a1d50709-3502-4faa-ba43-a5c7565e6a09': dict({
         'charge-chargelimits': dict({
           'values': list([
             dict({
@@ -121,13 +121,14 @@
     }),
     'metadata': dict({
     }),
+    'version': 'v2',
     'webhook_url': None,
   })
 # ---
 # name: test_entry_diagnostics[vw_id_4]
   dict({
     'data': dict({
-      'VIWP1AB29P15LA85784N': dict({
+      'a1d50709-3502-4faa-ba43-a5c7565e6a09': dict({
         'charge-chargelimits': dict({
           'values': list([
             dict({
@@ -265,13 +266,14 @@
     }),
     'metadata': dict({
     }),
+    'version': 'v2',
     'webhook_url': None,
   })
 # ---
 # name: test_entry_diagnostics_metadata[invalid_json]
   dict({
     'data': dict({
-      'VIWP1AB29P15LA85784N': None,
+      'a1d50709-3502-4faa-ba43-a5c7565e6a09': None,
     }),
     'entry': dict({
       'data': dict({
@@ -315,13 +317,14 @@
         'status': 204,
       }),
     }),
+    'version': 'v2',
     'webhook_url': 'http://10.10.10.10:8123/api/webhook/smartcar_test',
   })
 # ---
 # name: test_entry_diagnostics_metadata[location_redaction]
   dict({
     'data': dict({
-      'SADHA2A10M1610715': None,
+      'db745230-7f7c-4791-bcaa-185facf371be': None,
     }),
     'entry': dict({
       'data': dict({
@@ -894,13 +897,14 @@
         'status': 204,
       }),
     }),
+    'version': 'v2',
     'webhook_url': 'http://10.10.10.10:8123/api/webhook/smartcar_test',
   })
 # ---
 # name: test_entry_diagnostics_metadata[signature_validation_failure]
   dict({
     'data': dict({
-      'SADHA2A10M1610715': None,
+      'db745230-7f7c-4791-bcaa-185facf371be': None,
     }),
     'entry': dict({
       'data': dict({
@@ -1474,6 +1478,7 @@
         'status': 401,
       }),
     }),
+    'version': 'v2',
     'webhook_url': 'http://10.10.10.10:8123/api/webhook/smartcar_test',
   })
 # ---

--- a/tests/snapshots/test_diagnostics.ambr
+++ b/tests/snapshots/test_diagnostics.ambr
@@ -95,7 +95,7 @@
           'access_token': '**REDACTED**',
           'installed_app_id': '2d474f47-bab5-4438-9d37-478148b9d073',
           'refresh_token': '**REDACTED**',
-          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security',
+          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security read_diagnostics read_climate control_climate',
         }),
         'vehicles': dict({
           'a1d50709-3502-4faa-ba43-a5c7565e6a09': dict({
@@ -237,7 +237,7 @@
           'access_token': '**REDACTED**',
           'installed_app_id': '2d474f47-bab5-4438-9d37-478148b9d073',
           'refresh_token': '**REDACTED**',
-          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security',
+          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security read_diagnostics read_climate control_climate',
         }),
         'vehicles': dict({
           'a1d50709-3502-4faa-ba43-a5c7565e6a09': dict({
@@ -284,7 +284,7 @@
           'access_token': '**REDACTED**',
           'installed_app_id': '2d474f47-bab5-4438-9d37-478148b9d073',
           'refresh_token': '**REDACTED**',
-          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security',
+          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security read_diagnostics read_climate control_climate',
         }),
         'vehicles': dict({
           'a1d50709-3502-4faa-ba43-a5c7565e6a09': dict({
@@ -335,7 +335,7 @@
           'access_token': '**REDACTED**',
           'installed_app_id': '2d474f47-bab5-4438-9d37-478148b9d073',
           'refresh_token': '**REDACTED**',
-          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security',
+          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security read_diagnostics read_climate control_climate',
         }),
         'vehicles': dict({
           'db745230-7f7c-4791-bcaa-185facf371be': dict({
@@ -915,7 +915,7 @@
           'access_token': '**REDACTED**',
           'installed_app_id': '2d474f47-bab5-4438-9d37-478148b9d073',
           'refresh_token': '**REDACTED**',
-          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security',
+          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security read_diagnostics read_climate control_climate',
         }),
         'vehicles': dict({
           'db745230-7f7c-4791-bcaa-185facf371be': dict({

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -4315,7 +4315,7 @@
     'identifiers': set({
       tuple(
         'smartcar',
-        'VIWP1AB29P15LA85784N',
+        'a1d50709-3502-4faa-ba43-a5c7565e6a09',
       ),
     }),
     'labels': set({
@@ -4386,7 +4386,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_battery_capacity',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_battery_capacity',
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -4421,7 +4421,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_battery_level',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_battery_level',
       'unit_of_measurement': '%',
     }),
     EntityRegistryEntrySnapshot({
@@ -4454,7 +4454,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charging_state',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charging_state',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -4492,7 +4492,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_chargerate',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_chargerate',
       'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -4530,7 +4530,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_energyadded',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_energyadded',
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -4568,7 +4568,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_timetocomplete',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_timetocomplete',
       'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -4603,7 +4603,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_engine_oil',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_engine_oil',
       'unit_of_measurement': '%',
     }),
     EntityRegistryEntrySnapshot({
@@ -4638,7 +4638,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_fuel',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_fuel',
       'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -4676,7 +4676,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_odometer',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_odometer',
       'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -4714,7 +4714,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_range',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_range',
       'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -4752,7 +4752,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_back_left',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_tire_pressure_back_left',
       'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -4790,7 +4790,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_back_right',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_tire_pressure_back_right',
       'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -4828,7 +4828,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_front_left',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_tire_pressure_front_left',
       'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -4866,7 +4866,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_front_right',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_tire_pressure_front_right',
       'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -4899,7 +4899,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charging',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charging',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -4932,7 +4932,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_lock',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_lock',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -4965,7 +4965,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_plug_status',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_plug_status',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5003,7 +5003,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_limit',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_limit',
       'unit_of_measurement': '%',
     }),
     EntityRegistryEntrySnapshot({
@@ -5036,7 +5036,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_location',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_location',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5071,7 +5071,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_fuel_percent',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_fuel_percent',
       'unit_of_measurement': '%',
     }),
     EntityRegistryEntrySnapshot({
@@ -5109,7 +5109,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_fuel_range',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_fuel_range',
       'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -5144,7 +5144,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_low_voltage_battery_level',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_low_voltage_battery_level',
       'unit_of_measurement': '%',
     }),
     EntityRegistryEntrySnapshot({
@@ -5177,7 +5177,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_back_left',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_back_left',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5210,7 +5210,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_back_right',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_back_right',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5243,7 +5243,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_front_left',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_front_left',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5276,7 +5276,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_front_right',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_front_right',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5309,7 +5309,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_back_left_lock',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_back_left_lock',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5342,7 +5342,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_back_right_lock',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_back_right_lock',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5375,7 +5375,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_front_left_lock',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_front_left_lock',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5408,7 +5408,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_front_right_lock',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_front_right_lock',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5441,7 +5441,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_window_back_left',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_window_back_left',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5474,7 +5474,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_window_back_right',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_window_back_right',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5507,7 +5507,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_window_front_left',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_window_front_left',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5540,7 +5540,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_window_front_right',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_window_front_right',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5573,7 +5573,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_front_trunk',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_front_trunk',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5606,7 +5606,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_front_trunk_lock',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_front_trunk_lock',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5639,7 +5639,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_rear_trunk',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_rear_trunk',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5672,7 +5672,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_rear_trunk_lock',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_rear_trunk_lock',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5705,7 +5705,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_engine_cover',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_engine_cover',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5738,7 +5738,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_gear_state',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_gear_state',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5771,7 +5771,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_sunroof',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_sunroof',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5804,7 +5804,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_online',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_online',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5837,7 +5837,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_asleep',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_asleep',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5870,7 +5870,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_digital_key_paired',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_digital_key_paired',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5903,7 +5903,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_surveillance_enabled',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_surveillance_enabled',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5936,7 +5936,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_battery_heater_active',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_battery_heater_active',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -5974,7 +5974,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_voltage',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_voltage',
       'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -6012,7 +6012,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_amperage',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_amperage',
       'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -6050,7 +6050,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_wattage',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_wattage',
       'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -6088,7 +6088,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_time_to_complete',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_time_to_complete',
       'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -6126,7 +6126,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_amperage_max',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_amperage_max',
       'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -6159,7 +6159,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_fast_charger_present',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_fast_charger_present',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -6192,7 +6192,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_firmware_version',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_firmware_version',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -6225,7 +6225,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_last_webhook_received',
       'unit_of_measurement': None,
     }),
   ])
@@ -9793,7 +9793,7 @@
     'identifiers': set({
       tuple(
         'smartcar',
-        'VIWP1AB29P15LA85784N',
+        'a1d50709-3502-4faa-ba43-a5c7565e6a09',
       ),
     }),
     'labels': set({
@@ -9864,7 +9864,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_battery_capacity',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_battery_capacity',
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -9899,7 +9899,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_battery_level',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_battery_level',
       'unit_of_measurement': '%',
     }),
     EntityRegistryEntrySnapshot({
@@ -9932,7 +9932,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charging_state',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charging_state',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -9970,7 +9970,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_chargerate',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_chargerate',
       'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -10008,7 +10008,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_energyadded',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_energyadded',
       'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -10046,7 +10046,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_timetocomplete',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_timetocomplete',
       'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -10081,7 +10081,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_engine_oil',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_engine_oil',
       'unit_of_measurement': '%',
     }),
     EntityRegistryEntrySnapshot({
@@ -10116,7 +10116,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_fuel',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_fuel',
       'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -10154,7 +10154,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_odometer',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_odometer',
       'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -10192,7 +10192,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_range',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_range',
       'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -10230,7 +10230,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_back_left',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_tire_pressure_back_left',
       'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -10268,7 +10268,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_back_right',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_tire_pressure_back_right',
       'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -10306,7 +10306,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_front_left',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_tire_pressure_front_left',
       'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -10344,7 +10344,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_front_right',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_tire_pressure_front_right',
       'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -10377,7 +10377,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charging',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charging',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -10410,7 +10410,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_lock',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_lock',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -10443,7 +10443,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_plug_status',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_plug_status',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -10481,7 +10481,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_limit',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_limit',
       'unit_of_measurement': '%',
     }),
     EntityRegistryEntrySnapshot({
@@ -10514,7 +10514,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_location',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_location',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -10549,7 +10549,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_fuel_percent',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_fuel_percent',
       'unit_of_measurement': '%',
     }),
     EntityRegistryEntrySnapshot({
@@ -10587,7 +10587,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_fuel_range',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_fuel_range',
       'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -10622,7 +10622,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_low_voltage_battery_level',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_low_voltage_battery_level',
       'unit_of_measurement': '%',
     }),
     EntityRegistryEntrySnapshot({
@@ -10655,7 +10655,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_back_left',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_back_left',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -10688,7 +10688,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_back_right',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_back_right',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -10721,7 +10721,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_front_left',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_front_left',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -10754,7 +10754,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_front_right',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_front_right',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -10787,7 +10787,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_back_left_lock',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_back_left_lock',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -10820,7 +10820,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_back_right_lock',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_back_right_lock',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -10853,7 +10853,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_front_left_lock',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_front_left_lock',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -10886,7 +10886,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_door_front_right_lock',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_door_front_right_lock',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -10919,7 +10919,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_window_back_left',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_window_back_left',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -10952,7 +10952,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_window_back_right',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_window_back_right',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -10985,7 +10985,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_window_front_left',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_window_front_left',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11018,7 +11018,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_window_front_right',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_window_front_right',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11051,7 +11051,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_front_trunk',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_front_trunk',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11084,7 +11084,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_front_trunk_lock',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_front_trunk_lock',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11117,7 +11117,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_rear_trunk',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_rear_trunk',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11150,7 +11150,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_rear_trunk_lock',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_rear_trunk_lock',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11183,7 +11183,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_engine_cover',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_engine_cover',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11216,7 +11216,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_gear_state',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_gear_state',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11249,7 +11249,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_sunroof',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_sunroof',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11282,7 +11282,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_online',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_online',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11315,7 +11315,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_asleep',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_asleep',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11348,7 +11348,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_digital_key_paired',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_digital_key_paired',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11381,7 +11381,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_surveillance_enabled',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_surveillance_enabled',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11414,7 +11414,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_battery_heater_active',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_battery_heater_active',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11452,7 +11452,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_voltage',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_voltage',
       'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -11490,7 +11490,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_amperage',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_amperage',
       'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -11528,7 +11528,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_wattage',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_wattage',
       'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -11566,7 +11566,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_time_to_complete',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_time_to_complete',
       'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -11604,7 +11604,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_amperage_max',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_amperage_max',
       'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
     }),
     EntityRegistryEntrySnapshot({
@@ -11637,7 +11637,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_charge_fast_charger_present',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_charge_fast_charger_present',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11670,7 +11670,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_firmware_version',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_firmware_version',
       'unit_of_measurement': None,
     }),
     EntityRegistryEntrySnapshot({
@@ -11703,7 +11703,7 @@
       'suggested_object_id': None,
       'supported_features': 0,
       'translation_key': None,
-      'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_last_webhook_received',
       'unit_of_measurement': None,
     }),
   ])

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -359,6 +359,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup[unknown_make][binary_sensor.smartcar_784n_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'Smartcar 784N Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_standard_setup[unknown_make][binary_sensor.smartcar_784n_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -433,6 +447,25 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_standard_setup[unknown_make][device_tracker.smartcar_784n_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
+      'friendly_name': 'Smartcar 784N Location',
+      'gps_accuracy': 0,
+      'icon': 'mdi:car',
+      'latitude': 37.4292,
+      'longitude': 122.1381,
+      'source_type': <SourceType.GPS: 'gps'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.smartcar_784n_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup[unknown_make][entities]
@@ -1179,6 +1212,20 @@
     }),
   ])
 # ---
+# name: test_standard_setup[unknown_make][lock.smartcar_784n_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.smartcar_784n_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unlocked',
+  })
+# ---
 # name: test_standard_setup[unknown_make][sensor.smartcar_784n_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1191,6 +1238,22 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Smartcar 784N Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30',
   })
 # ---
 # name: test_standard_setup[unknown_make][sensor.smartcar_784n_cabin_target_temperature]
@@ -1208,6 +1271,20 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'FULLY_CHARGED',
   })
 # ---
 # name: test_standard_setup[unknown_make][sensor.smartcar_784n_ev_battery_conditioning_status]
@@ -1266,6 +1343,21 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Smartcar 784N Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_standard_setup[unknown_make][sensor.smartcar_784n_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1278,6 +1370,23 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '40.5',
   })
 # ---
 # name: test_standard_setup[unknown_make][sensor.smartcar_784n_trouble_code_count]
@@ -1309,6 +1418,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup[unknown_make][switch.smartcar_784n_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.smartcar_784n_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup[unknown_make][switch.smartcar_784n_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1336,6 +1459,22 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'device_class': 'plug',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
   })
 # ---
 # name: test_standard_setup[vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
@@ -1412,6 +1551,26 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_standard_setup[vw_id_4][device_tracker.vw_id_4_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:52+00:00',
+      'fetched_at': '2025-05-09T17:27:25.401000+00:00',
+      'friendly_name': 'VW ID.4 Location',
+      'gps_accuracy': 0,
+      'icon': 'mdi:car',
+      'latitude': 37.4292,
+      'longitude': 122.1381,
+      'source_type': <SourceType.GPS: 'gps'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.vw_id_4_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup[vw_id_4][entities]
@@ -2158,6 +2317,20 @@
     }),
   ])
 # ---
+# name: test_standard_setup[vw_id_4][lock.vw_id_4_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vw_id_4_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup[vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2170,6 +2343,24 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'device_class': 'battery',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '68',
   })
 # ---
 # name: test_standard_setup[vw_id_4][sensor.vw_id_4_cabin_target_temperature]
@@ -2187,6 +2378,22 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'NOT_CHARGING',
   })
 # ---
 # name: test_standard_setup[vw_id_4][sensor.vw_id_4_ev_battery_conditioning_status]
@@ -2245,6 +2452,21 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'VW ID.4 Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_standard_setup[vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2257,6 +2479,25 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'device_class': 'distance',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '275',
   })
 # ---
 # name: test_standard_setup[vw_id_4][sensor.vw_id_4_trouble_code_count]
@@ -2288,6 +2529,22 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup[vw_id_4][switch.vw_id_4_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup[vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2296,6 +2553,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.vw_id_4_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2317,6 +2600,181 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'Smartcar 784N Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'Smartcar 784N Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2326,6 +2784,47 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2347,6 +2846,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2356,6 +2883,89 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.smartcar_784n_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2391,6 +3001,25 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][device_tracker.smartcar_784n_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
+      'friendly_name': 'Smartcar 784N Location',
+      'gps_accuracy': 0,
+      'icon': 'mdi:car',
+      'latitude': 37.4292,
+      'longitude': 122.1381,
+      'source_type': <SourceType.GPS: 'gps'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.smartcar_784n_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][entities]
@@ -4743,6 +5372,39 @@
     }),
   ])
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][lock.smartcar_784n_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.smartcar_784n_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unlocked',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][number.smartcar_784n_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.smartcar_784n_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4755,6 +5417,38 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Smartcar 784N Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'Smartcar 784N Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '70.9',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_cabin_target_temperature]
@@ -4772,6 +5466,150 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'Smartcar 784N Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Smartcar 784N Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Smartcar 784N Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Smartcar 784N Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'FULLY_CHARGED',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Smartcar 784N Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'Smartcar 784N Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'Smartcar 784N Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_engine_oil_life',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.35',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_ev_battery_conditioning_status]
@@ -4830,6 +5668,114 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '53.2',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '40.5',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Smartcar 784N Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Smartcar 784N Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4842,6 +5788,125 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '37829',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '40.5',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Smartcar 784N Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '219.3',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '219.3',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '219.3',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '219.3',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_trouble_code_count]
@@ -4873,6 +5938,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][switch.smartcar_784n_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.smartcar_784n_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][switch.smartcar_784n_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4881,6 +5960,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.smartcar_784n_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4902,6 +6007,181 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'Smartcar 784N Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'Smartcar 784N Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4911,6 +6191,47 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4932,6 +6253,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4945,6 +6294,89 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][device]
@@ -4976,6 +6408,24 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][device_tracker.smartcar_784n_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Location',
+      'gps_accuracy': 0,
+      'icon': 'mdi:car',
+      'latitude': 37.4292,
+      'longitude': 122.1381,
+      'source_type': <SourceType.GPS: 'gps'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.smartcar_784n_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][entities]
@@ -7328,6 +8778,39 @@
     }),
   ])
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][lock.smartcar_784n_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.smartcar_784n_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unlocked',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][number.smartcar_784n_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.smartcar_784n_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -7336,6 +8819,38 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.smartcar_784n_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Smartcar 784N Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'Smartcar 784N Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_battery_capacity',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -7357,6 +8872,152 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'Smartcar 784N Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Smartcar 784N Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Smartcar 784N Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Smartcar 784N Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'FULLY_CHARGED',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Smartcar 784N Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'Smartcar 784N Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'Smartcar 784N Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-09-18T23:30:33+00:00',
+      'fetched_at': '2025-09-18T23:39:43.086000+00:00',
+      'friendly_name': 'Smartcar 784N Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_engine_oil_life',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0035',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_ev_battery_conditioning_status]
@@ -7415,6 +9076,116 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-09-18T23:30:33+00:00',
+      'fetched_at': '2025-09-18T23:39:43.086000+00:00',
+      'friendly_name': 'Smartcar 784N Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Smartcar 784N Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Smartcar 784N Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -7423,6 +9194,120 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.smartcar_784n_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '37829',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Smartcar 784N Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -7458,6 +9343,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][switch.smartcar_784n_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.smartcar_784n_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][switch.smartcar_784n_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -7466,6 +9365,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.smartcar_784n_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -7487,6 +9412,183 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'device_class': 'plug',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -7496,6 +9598,47 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -7517,6 +9660,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -7526,6 +9697,89 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -7561,6 +9815,26 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][device_tracker.vw_id_4_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:52+00:00',
+      'fetched_at': '2025-05-09T17:27:25.401000+00:00',
+      'friendly_name': 'VW ID.4 Location',
+      'gps_accuracy': 0,
+      'icon': 'mdi:car',
+      'latitude': 37.4292,
+      'longitude': 122.1381,
+      'source_type': <SourceType.GPS: 'gps'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.vw_id_4_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][entities]
@@ -9913,6 +12187,41 @@
     }),
   ])
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][lock.vw_id_4_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vw_id_4_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][number.vw_id_4_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:55+00:00',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.vw_id_4_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -9927,6 +12236,42 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'device_class': 'battery',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '68',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T17:27:25.114000+00:00',
+      'device_class': 'energy_storage',
+      'fetched_at': '2025-05-09T17:27:25.114000+00:00',
+      'friendly_name': 'VW ID.4 Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '82',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -9938,6 +12283,152 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'VW ID.4 Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'VW ID.4 Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'NOT_CHARGING',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'VW ID.4 Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_engine_oil_life',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -10000,6 +12491,114 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'VW ID.4 Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -10008,6 +12607,124 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:52+00:00',
+      'device_class': 'distance',
+      'fetched_at': '2025-05-09T17:27:25.401000+00:00',
+      'friendly_name': 'VW ID.4 Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '21919',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'device_class': 'distance',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '275',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -10043,6 +12760,22 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][switch.vw_id_4_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -10051,6 +12784,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.vw_id_4_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -10072,6 +12831,181 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -10085,6 +13019,47 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_online',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
   })
 # ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_defroster_active]
@@ -10102,6 +13077,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -10115,6 +13118,89 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
   })
 # ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][device]
@@ -10146,6 +13232,24 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][device_tracker.vw_id_4_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Location',
+      'gps_accuracy': 0,
+      'icon': 'mdi:car',
+      'latitude': 37.4292,
+      'longitude': 122.1381,
+      'source_type': <SourceType.GPS: 'gps'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.vw_id_4_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][entities]
@@ -12498,6 +15602,39 @@
     }),
   ])
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][lock.vw_id_4_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vw_id_4_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'locked',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][number.vw_id_4_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.vw_id_4_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -12506,6 +15643,38 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '57',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery_capacity',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12523,6 +15692,150 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'VW ID.4 Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'VW ID.4 Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'NOT_CHARGING',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'VW ID.4 Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_engine_oil_life',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12585,6 +15898,114 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'VW ID.4 Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -12593,6 +16014,120 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '52891',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '253',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12628,6 +16163,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][switch.vw_id_4_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -12636,6 +16185,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.vw_id_4_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12657,6 +16232,181 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -12666,6 +16416,47 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12687,6 +16478,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -12696,6 +16515,89 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12731,6 +16633,20 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][device_tracker.vw_id_4_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Location',
+      'icon': 'mdi:car',
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.vw_id_4_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[network_error-vw_id_4][entities]
@@ -15083,6 +18999,39 @@
     }),
   ])
 # ---
+# name: test_update_errors[network_error-vw_id_4][lock.vw_id_4_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vw_id_4_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][number.vw_id_4_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.vw_id_4_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -15091,6 +19040,38 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery_capacity',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -15108,6 +19089,150 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'VW ID.4 Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'VW ID.4 Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'VW ID.4 Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_engine_oil_life',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -15170,6 +19295,114 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'VW ID.4 Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -15178,6 +19411,120 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -15213,6 +19560,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_error-vw_id_4][switch.vw_id_4_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_error-vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -15221,6 +19582,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.vw_id_4_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -15242,6 +19629,181 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -15251,6 +19813,47 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -15272,6 +19875,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -15281,6 +19912,89 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -15316,6 +20030,20 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][device_tracker.vw_id_4_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Location',
+      'icon': 'mdi:car',
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.vw_id_4_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[network_proxy_response-vw_id_4][entities]
@@ -17668,6 +22396,39 @@
     }),
   ])
 # ---
+# name: test_update_errors[network_proxy_response-vw_id_4][lock.vw_id_4_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vw_id_4_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][number.vw_id_4_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.vw_id_4_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -17676,6 +22437,38 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery_capacity',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -17693,6 +22486,150 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'VW ID.4 Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'VW ID.4 Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'VW ID.4 Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_engine_oil_life',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -17755,6 +22692,114 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'VW ID.4 Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -17763,6 +22808,120 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -17798,6 +22957,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_proxy_response-vw_id_4][switch.vw_id_4_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_proxy_response-vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -17806,6 +22979,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.vw_id_4_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -17827,6 +23026,181 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -17836,6 +23210,47 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -17857,6 +23272,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -17866,6 +23309,89 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -17901,6 +23427,20 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][device_tracker.vw_id_4_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Location',
+      'icon': 'mdi:car',
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.vw_id_4_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[server_error-vw_id_4][entities]
@@ -20253,6 +25793,39 @@
     }),
   ])
 # ---
+# name: test_update_errors[server_error-vw_id_4][lock.vw_id_4_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vw_id_4_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][number.vw_id_4_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.vw_id_4_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -20261,6 +25834,38 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery_capacity',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -20278,6 +25883,150 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'VW ID.4 Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'VW ID.4 Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'VW ID.4 Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_engine_oil_life',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -20340,6 +26089,114 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'VW ID.4 Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -20348,6 +26205,120 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -20383,6 +26354,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[server_error-vw_id_4][switch.vw_id_4_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[server_error-vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -20391,6 +26376,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.vw_id_4_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -20412,6 +26423,181 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -20421,6 +26607,47 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -20442,6 +26669,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -20451,6 +26706,89 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -20486,6 +26824,20 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][device_tracker.vw_id_4_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Location',
+      'icon': 'mdi:car',
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.vw_id_4_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[unauthorized-vw_id_4][entities]
@@ -22838,6 +29190,39 @@
     }),
   ])
 # ---
+# name: test_update_errors[unauthorized-vw_id_4][lock.vw_id_4_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vw_id_4_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][number.vw_id_4_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.vw_id_4_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -22846,6 +29231,38 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery_capacity',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -22863,6 +29280,150 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'VW ID.4 Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'VW ID.4 Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'VW ID.4 Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_engine_oil_life',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -22925,6 +29486,114 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'VW ID.4 Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -22933,6 +29602,120 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -22962,6 +29745,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][switch.vw_id_4_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_charging',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -1213,7 +1213,7 @@
     'state': 'off',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_asleep]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_asleep]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smartcar 784N Asleep',
@@ -1226,7 +1226,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_battery_heater_active]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_battery_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smartcar 784N Battery Heater Active',
@@ -1239,7 +1239,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_charging_cable_plugged_in]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_charging_cable_plugged_in]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'plug',
@@ -1253,7 +1253,7 @@
     'state': 'on',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_digital_key_paired]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_digital_key_paired]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smartcar 784N Digital Key Paired',
@@ -1266,7 +1266,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_door_back_left]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -1281,7 +1281,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_door_back_left_lock]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_left_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'lock',
@@ -1296,7 +1296,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_door_back_right]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -1311,7 +1311,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_door_back_right_lock]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_right_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'lock',
@@ -1326,7 +1326,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_door_front_left]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -1341,7 +1341,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_door_front_left_lock]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_left_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'lock',
@@ -1356,7 +1356,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_door_front_right]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -1371,7 +1371,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_door_front_right_lock]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_right_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'lock',
@@ -1386,7 +1386,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_engine_cover]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_engine_cover]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -1400,7 +1400,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_fast_charger_connected]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_fast_charger_connected]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'plug',
@@ -1414,7 +1414,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_front_trunk]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_front_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -1428,7 +1428,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_front_trunk_lock]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_front_trunk_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'lock',
@@ -1442,7 +1442,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_online]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_online]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smartcar 784N Online',
@@ -1455,7 +1455,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_rear_trunk]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_rear_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -1469,7 +1469,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_rear_trunk_lock]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_rear_trunk_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'lock',
@@ -1483,7 +1483,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_sunroof]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_sunroof]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -1497,7 +1497,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_surveillance_enabled]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_surveillance_enabled]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smartcar 784N Surveillance Enabled',
@@ -1510,7 +1510,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_window_back_left]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_back_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'window',
@@ -1524,7 +1524,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_window_back_right]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_back_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'window',
@@ -1538,7 +1538,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_window_front_left]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_front_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'window',
@@ -1552,7 +1552,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][binary_sensor.smartcar_784n_window_front_right]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_front_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'window',
@@ -1566,7 +1566,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][device]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][device]
   DeviceRegistryEntrySnapshot({
     'area_id': None,
     'config_entries': <ANY>,
@@ -1597,7 +1597,7 @@
     'via_device_id': None,
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][device_tracker.smartcar_784n_location]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][device_tracker.smartcar_784n_location]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'age': '2019-10-24T00:43:46+00:00',
@@ -1616,7 +1616,7 @@
     'state': 'not_home',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][entities]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][entities]
   list([
     EntityRegistryEntrySnapshot({
       'aliases': set({
@@ -3497,7 +3497,7 @@
     }),
   ])
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][lock.smartcar_784n_door_lock]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][lock.smartcar_784n_door_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smartcar 784N Door Lock',
@@ -3511,7 +3511,7 @@
     'state': 'unlocked',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][number.smartcar_784n_charge_limit]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][number.smartcar_784n_charge_limit]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smartcar 784N Charge Limit',
@@ -3530,7 +3530,7 @@
     'state': '80',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_battery]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'battery',
@@ -3546,7 +3546,7 @@
     'state': '30',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_battery_capacity]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_battery_capacity]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy_storage',
@@ -3562,7 +3562,7 @@
     'state': '70.9',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_charge_rate]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charge_rate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'speed',
@@ -3579,7 +3579,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_charging_current]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_current]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'current',
@@ -3595,7 +3595,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_charging_current_max]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_current_max]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'current',
@@ -3611,7 +3611,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_charging_power]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_power]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'power',
@@ -3627,7 +3627,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_charging_status]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smartcar 784N Charging Status',
@@ -3641,7 +3641,7 @@
     'state': 'FULLY_CHARGED',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_charging_time_remaining]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_time_remaining]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
@@ -3657,7 +3657,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_charging_voltage]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_voltage]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'voltage',
@@ -3673,7 +3673,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_energy_added]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_energy_added]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy_storage',
@@ -3690,7 +3690,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_engine_oil_life]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_engine_oil_life]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smartcar 784N Engine Oil Life',
@@ -3706,7 +3706,7 @@
     'state': '0.35',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_firmware_version]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smartcar 784N Firmware Version',
@@ -3720,7 +3720,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_fuel]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_fuel]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smartcar 784N Fuel',
@@ -3736,7 +3736,7 @@
     'state': '53.2',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_fuel_percent]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_fuel_percent]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smartcar 784N Fuel Percent',
@@ -3752,7 +3752,7 @@
     'state': '30',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_fuel_range]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_fuel_range]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'distance',
@@ -3769,7 +3769,7 @@
     'state': '40.5',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_gear_state]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_gear_state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smartcar 784N Gear State',
@@ -3783,7 +3783,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_last_webhook_received]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_last_webhook_received]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'timestamp',
@@ -3798,7 +3798,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_low_voltage_battery]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_low_voltage_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'battery',
@@ -3814,7 +3814,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_odometer]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_odometer]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'age': '2019-10-24T00:43:46+00:00',
@@ -3831,7 +3831,7 @@
     'state': '37829',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_range]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_range]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'distance',
@@ -3848,7 +3848,7 @@
     'state': '40.5',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_time_to_complete]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_time_to_complete]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
@@ -3865,7 +3865,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_tire_pressure_back_left]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_back_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'age': '2019-10-24T00:43:46+00:00',
@@ -3882,7 +3882,7 @@
     'state': '219.3',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_tire_pressure_back_right]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_back_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'age': '2019-10-24T00:43:46+00:00',
@@ -3899,7 +3899,7 @@
     'state': '219.3',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_tire_pressure_front_left]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_front_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'age': '2019-10-24T00:43:46+00:00',
@@ -3916,7 +3916,7 @@
     'state': '219.3',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][sensor.smartcar_784n_tire_pressure_front_right]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_front_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'age': '2019-10-24T00:43:46+00:00',
@@ -3933,7 +3933,7 @@
     'state': '219.3',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make][switch.smartcar_784n_charging]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][switch.smartcar_784n_charging]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Smartcar 784N Charging',
@@ -3947,7 +3947,2739 @@
     'state': 'off',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_asleep]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_battery_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'Smartcar 784N Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'Smartcar 784N Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_online',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][device]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'smartcar',
+        'VIWP1AB29P15LA85784N',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': None,
+    'model': None,
+    'model_id': None,
+    'name': 'Smartcar 784N',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][device_tracker.smartcar_784n_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Location',
+      'gps_accuracy': 0,
+      'icon': 'mdi:car',
+      'latitude': 37.4292,
+      'longitude': 122.1381,
+      'source_type': <SourceType.GPS: 'gps'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.smartcar_784n_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_home',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][entities]
+  list([
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_battery_capacity',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY_STORAGE: 'energy_storage'>,
+      'original_icon': None,
+      'original_name': 'Battery Capacity',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_battery_capacity',
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_battery',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+      'original_icon': None,
+      'original_name': 'Battery',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_battery_level',
+      'unit_of_measurement': '%',
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charging_state',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_charge_rate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.SPEED: 'speed'>,
+      'original_icon': 'mdi:speedometer',
+      'original_name': 'Charge Rate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_chargerate',
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_energy_added',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY_STORAGE: 'energy_storage'>,
+      'original_icon': 'mdi:lightning-bolt',
+      'original_name': 'Energy Added',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_energyadded',
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_time_to_complete',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+      'original_icon': 'mdi:timer',
+      'original_name': 'Time to Complete',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_timetocomplete',
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_engine_oil_life',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:oil-level',
+      'original_name': 'Engine Oil Life',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_engine_oil',
+      'unit_of_measurement': '%',
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_fuel',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:gas-station',
+      'original_name': 'Fuel',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_fuel',
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_odometer',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
+      'original_icon': None,
+      'original_name': 'Odometer',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_odometer',
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_range',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
+      'original_icon': 'mdi:map-marker-distance',
+      'original_name': 'Range',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_range',
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_tire_pressure_back_left',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+      'original_icon': None,
+      'original_name': 'Tire Pressure Back Left',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_back_left',
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_tire_pressure_back_right',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+      'original_icon': None,
+      'original_name': 'Tire Pressure Back Right',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_back_right',
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_tire_pressure_front_left',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+      'original_icon': None,
+      'original_name': 'Tire Pressure Front Left',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_front_left',
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_tire_pressure_front_right',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+      'original_icon': None,
+      'original_name': 'Tire Pressure Front Right',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_front_right',
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.smartcar_784n_charging',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-plug-type2',
+      'original_name': 'Charging',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'lock',
+      'entity_category': None,
+      'entity_id': 'lock.smartcar_784n_door_lock',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Door Lock',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_lock',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_charging_cable_plugged_in',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.PLUG: 'plug'>,
+      'original_icon': None,
+      'original_name': 'Charging Cable Plugged In',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_plug_status',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'max': 100.0,
+        'min': 50.0,
+        'mode': <NumberMode.BOX: 'box'>,
+        'step': 1.0,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'number',
+      'entity_category': None,
+      'entity_id': 'number.smartcar_784n_charge_limit',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-charging-80',
+      'original_name': 'Charge Limit',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_limit',
+      'unit_of_measurement': '%',
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'device_tracker',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'device_tracker.smartcar_784n_location',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car',
+      'original_name': 'Location',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_location',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_fuel_percent',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:gas-station',
+      'original_name': 'Fuel Percent',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_fuel_percent',
+      'unit_of_measurement': '%',
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_fuel_range',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
+      'original_icon': 'mdi:map-marker-distance',
+      'original_name': 'Fuel Range',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_fuel_range',
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_low_voltage_battery',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+      'original_icon': None,
+      'original_name': 'Low Voltage Battery',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_low_voltage_battery_level',
+      'unit_of_measurement': '%',
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_door_back_left',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': 'mdi:car-door',
+      'original_name': 'Door Back Left',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_back_left',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_door_back_right',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': 'mdi:car-door',
+      'original_name': 'Door Back Right',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_back_right',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_door_front_left',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': 'mdi:car-door',
+      'original_name': 'Door Front Left',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_front_left',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_door_front_right',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': 'mdi:car-door',
+      'original_name': 'Door Front Right',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_front_right',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_door_back_left_lock',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+      'original_icon': 'mdi:car-door-lock',
+      'original_name': 'Door Back Left Lock',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_back_left_lock',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_door_back_right_lock',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+      'original_icon': 'mdi:car-door-lock',
+      'original_name': 'Door Back Right Lock',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_back_right_lock',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_door_front_left_lock',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+      'original_icon': 'mdi:car-door-lock',
+      'original_name': 'Door Front Left Lock',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_front_left_lock',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_door_front_right_lock',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+      'original_icon': 'mdi:car-door-lock',
+      'original_name': 'Door Front Right Lock',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_front_right_lock',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_window_back_left',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.WINDOW: 'window'>,
+      'original_icon': None,
+      'original_name': 'Window Back Left',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_window_back_left',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_window_back_right',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.WINDOW: 'window'>,
+      'original_icon': None,
+      'original_name': 'Window Back Right',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_window_back_right',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_window_front_left',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.WINDOW: 'window'>,
+      'original_icon': None,
+      'original_name': 'Window Front Left',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_window_front_left',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_window_front_right',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.WINDOW: 'window'>,
+      'original_icon': None,
+      'original_name': 'Window Front Right',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_window_front_right',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_front_trunk',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': None,
+      'original_name': 'Front Trunk',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_front_trunk',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_front_trunk_lock',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+      'original_icon': None,
+      'original_name': 'Front Trunk Lock',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_front_trunk_lock',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_rear_trunk',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': None,
+      'original_name': 'Rear Trunk',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_rear_trunk',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_rear_trunk_lock',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+      'original_icon': None,
+      'original_name': 'Rear Trunk Lock',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_rear_trunk_lock',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_engine_cover',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': None,
+      'original_name': 'Engine Cover',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_engine_cover',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_gear_state',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-parking',
+      'original_name': 'Gear State',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_gear_state',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_sunroof',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': None,
+      'original_name': 'Sunroof',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_sunroof',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_online',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Online',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_online',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_asleep',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Asleep',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_asleep',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_digital_key_paired',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Digital Key Paired',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_digital_key_paired',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_surveillance_enabled',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Surveillance Enabled',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_surveillance_enabled',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_battery_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Battery Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_battery_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_charging_voltage',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 0,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+      'original_icon': None,
+      'original_name': 'Charging Voltage',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_voltage',
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_charging_current',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+      'original_icon': None,
+      'original_name': 'Charging Current',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_amperage',
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_charging_power',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+      'original_icon': None,
+      'original_name': 'Charging Power',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_wattage',
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_charging_time_remaining',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+      'original_icon': None,
+      'original_name': 'Charging Time Remaining',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_time_to_complete',
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_charging_current_max',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+      'original_icon': None,
+      'original_name': 'Charging Current Max',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_amperage_max',
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_fast_charger_connected',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.PLUG: 'plug'>,
+      'original_icon': None,
+      'original_name': 'Fast Charger Connected',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_fast_charger_present',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_firmware_version',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:chip',
+      'original_name': 'Firmware Version',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_firmware_version',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_last_webhook_received',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+      'original_icon': 'mdi:clock',
+      'original_name': 'Last Webhook Received',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
+      'unit_of_measurement': None,
+    }),
+  ])
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][lock.smartcar_784n_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.smartcar_784n_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unlocked',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][number.smartcar_784n_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.smartcar_784n_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Smartcar 784N Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'Smartcar 784N Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'Smartcar 784N Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Smartcar 784N Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Smartcar 784N Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Smartcar 784N Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'FULLY_CHARGED',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Smartcar 784N Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'Smartcar 784N Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'Smartcar 784N Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-09-18T23:30:33+00:00',
+      'fetched_at': '2025-09-18T23:39:43.086000+00:00',
+      'friendly_name': 'Smartcar 784N Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_engine_oil_life',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0035',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-09-18T23:30:33+00:00',
+      'fetched_at': '2025-09-18T23:39:43.086000+00:00',
+      'friendly_name': 'Smartcar 784N Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Smartcar 784N Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Smartcar 784N Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '37829',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Smartcar 784N Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][switch.smartcar_784n_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.smartcar_784n_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_asleep]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'VW ID.4 Asleep',
@@ -3960,7 +6692,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_battery_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'VW ID.4 Battery Heater Active',
@@ -3973,7 +6705,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_charging_cable_plugged_in]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'age': '2025-05-09T15:40:57+00:00',
@@ -3989,7 +6721,7 @@
     'state': 'off',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_digital_key_paired]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'VW ID.4 Digital Key Paired',
@@ -4002,7 +6734,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_door_back_left]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -4017,7 +6749,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_left_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'lock',
@@ -4032,7 +6764,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_door_back_right]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -4047,7 +6779,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_right_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'lock',
@@ -4062,7 +6794,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_door_front_left]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -4077,7 +6809,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_left_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'lock',
@@ -4092,7 +6824,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_door_front_right]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -4107,7 +6839,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_right_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'lock',
@@ -4122,7 +6854,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_engine_cover]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_engine_cover]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -4136,7 +6868,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_fast_charger_connected]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'plug',
@@ -4150,7 +6882,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_front_trunk]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_front_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -4164,7 +6896,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_front_trunk_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'lock',
@@ -4178,7 +6910,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_online]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_online]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'VW ID.4 Online',
@@ -4191,7 +6923,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_rear_trunk]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_rear_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -4205,7 +6937,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_rear_trunk_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'lock',
@@ -4219,7 +6951,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_sunroof]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_sunroof]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'door',
@@ -4233,7 +6965,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_surveillance_enabled]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'VW ID.4 Surveillance Enabled',
@@ -4246,7 +6978,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_window_back_left]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_back_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'window',
@@ -4260,7 +6992,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_window_back_right]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_back_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'window',
@@ -4274,7 +7006,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_window_front_left]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_front_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'window',
@@ -4288,7 +7020,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][binary_sensor.vw_id_4_window_front_right]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_front_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'window',
@@ -4302,7 +7034,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][device]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][device]
   DeviceRegistryEntrySnapshot({
     'area_id': None,
     'config_entries': <ANY>,
@@ -4333,7 +7065,7 @@
     'via_device_id': None,
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][device_tracker.vw_id_4_location]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][device_tracker.vw_id_4_location]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'age': '2025-05-09T15:40:52+00:00',
@@ -4353,7 +7085,7 @@
     'state': 'not_home',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][entities]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][entities]
   list([
     EntityRegistryEntrySnapshot({
       'aliases': set({
@@ -6234,7 +8966,7 @@
     }),
   ])
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][lock.vw_id_4_door_lock]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][lock.vw_id_4_door_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'VW ID.4 Door Lock',
@@ -6248,7 +8980,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][number.vw_id_4_charge_limit]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][number.vw_id_4_charge_limit]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'age': '2025-05-09T15:40:55+00:00',
@@ -6269,7 +9001,7 @@
     'state': '100',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_battery]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'age': '2025-05-09T15:40:57+00:00',
@@ -6287,7 +9019,7 @@
     'state': '68',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_battery_capacity]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_battery_capacity]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'age': '2025-05-09T17:27:25.114000+00:00',
@@ -6305,7 +9037,7 @@
     'state': '82',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_charge_rate]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charge_rate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'speed',
@@ -6322,7 +9054,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_charging_current]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_current]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'current',
@@ -6338,7 +9070,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_charging_current_max]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_current_max]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'current',
@@ -6354,7 +9086,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_charging_power]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_power]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'power',
@@ -6370,7 +9102,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_charging_status]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'age': '2025-05-09T15:40:57+00:00',
@@ -6386,7 +9118,7 @@
     'state': 'NOT_CHARGING',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_charging_time_remaining]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_time_remaining]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
@@ -6402,7 +9134,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_charging_voltage]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_voltage]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'voltage',
@@ -6418,7 +9150,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_energy_added]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_energy_added]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'energy_storage',
@@ -6435,7 +9167,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_engine_oil_life]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_engine_oil_life]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'VW ID.4 Engine Oil Life',
@@ -6451,7 +9183,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_firmware_version]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'VW ID.4 Firmware Version',
@@ -6465,7 +9197,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_fuel]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_fuel]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'VW ID.4 Fuel',
@@ -6481,7 +9213,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_fuel_percent]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_fuel_percent]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'VW ID.4 Fuel Percent',
@@ -6497,7 +9229,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_fuel_range]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_fuel_range]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'distance',
@@ -6514,7 +9246,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_gear_state]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_gear_state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'VW ID.4 Gear State',
@@ -6528,7 +9260,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_last_webhook_received]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_last_webhook_received]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'timestamp',
@@ -6543,7 +9275,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_low_voltage_battery]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_low_voltage_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'battery',
@@ -6559,7 +9291,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_odometer]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_odometer]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'age': '2025-05-09T15:40:52+00:00',
@@ -6577,7 +9309,7 @@
     'state': '21919',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_range]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_range]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'age': '2025-05-09T15:40:57+00:00',
@@ -6596,7 +9328,7 @@
     'state': '275',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_time_to_complete]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_time_to_complete]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'duration',
@@ -6613,7 +9345,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_back_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'pressure',
@@ -6629,7 +9361,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_back_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'pressure',
@@ -6645,7 +9377,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_front_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'pressure',
@@ -6661,7 +9393,7 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_front_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'device_class': 'pressure',
@@ -6677,11 +9409,2739 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4][switch.vw_id_4_charging]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][switch.vw_id_4_charging]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'age': '2025-05-09T15:40:57+00:00',
       'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_online',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][device]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'smartcar',
+        'VIWP1AB29P15LA85784N',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'VW',
+    'model': 'ID.4 (2021)',
+    'model_id': None,
+    'name': 'VW ID.4',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][device_tracker.vw_id_4_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Location',
+      'gps_accuracy': 0,
+      'icon': 'mdi:car',
+      'latitude': 37.4292,
+      'longitude': 122.1381,
+      'source_type': <SourceType.GPS: 'gps'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.vw_id_4_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_home',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][entities]
+  list([
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_battery_capacity',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY_STORAGE: 'energy_storage'>,
+      'original_icon': None,
+      'original_name': 'Battery Capacity',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_battery_capacity',
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_battery',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+      'original_icon': None,
+      'original_name': 'Battery',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_battery_level',
+      'unit_of_measurement': '%',
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charging_state',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_charge_rate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.SPEED: 'speed'>,
+      'original_icon': 'mdi:speedometer',
+      'original_name': 'Charge Rate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_chargerate',
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_energy_added',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY_STORAGE: 'energy_storage'>,
+      'original_icon': 'mdi:lightning-bolt',
+      'original_name': 'Energy Added',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_energyadded',
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_time_to_complete',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+      'original_icon': 'mdi:timer',
+      'original_name': 'Time to Complete',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_timetocomplete',
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_engine_oil_life',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:oil-level',
+      'original_name': 'Engine Oil Life',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_engine_oil',
+      'unit_of_measurement': '%',
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_fuel',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:gas-station',
+      'original_name': 'Fuel',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_fuel',
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_odometer',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
+      'original_icon': None,
+      'original_name': 'Odometer',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_odometer',
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_range',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
+      'original_icon': 'mdi:map-marker-distance',
+      'original_name': 'Range',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_range',
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+      'original_icon': None,
+      'original_name': 'Tire Pressure Back Left',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_back_left',
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+      'original_icon': None,
+      'original_name': 'Tire Pressure Back Right',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_back_right',
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+      'original_icon': None,
+      'original_name': 'Tire Pressure Front Left',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_front_left',
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+      'original_icon': None,
+      'original_name': 'Tire Pressure Front Right',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_tire_pressure_front_right',
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.vw_id_4_charging',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-plug-type2',
+      'original_name': 'Charging',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'lock',
+      'entity_category': None,
+      'entity_id': 'lock.vw_id_4_door_lock',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Door Lock',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_lock',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.PLUG: 'plug'>,
+      'original_icon': None,
+      'original_name': 'Charging Cable Plugged In',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_plug_status',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'max': 100.0,
+        'min': 50.0,
+        'mode': <NumberMode.BOX: 'box'>,
+        'step': 1.0,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'number',
+      'entity_category': None,
+      'entity_id': 'number.vw_id_4_charge_limit',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-charging-80',
+      'original_name': 'Charge Limit',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_limit',
+      'unit_of_measurement': '%',
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'device_tracker',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'device_tracker.vw_id_4_location',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car',
+      'original_name': 'Location',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_location',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_fuel_percent',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:gas-station',
+      'original_name': 'Fuel Percent',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_fuel_percent',
+      'unit_of_measurement': '%',
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_fuel_range',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
+      'original_icon': 'mdi:map-marker-distance',
+      'original_name': 'Fuel Range',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_fuel_range',
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+      'original_icon': None,
+      'original_name': 'Low Voltage Battery',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_low_voltage_battery_level',
+      'unit_of_measurement': '%',
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_door_back_left',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': 'mdi:car-door',
+      'original_name': 'Door Back Left',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_back_left',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_door_back_right',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': 'mdi:car-door',
+      'original_name': 'Door Back Right',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_back_right',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_door_front_left',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': 'mdi:car-door',
+      'original_name': 'Door Front Left',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_front_left',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_door_front_right',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': 'mdi:car-door',
+      'original_name': 'Door Front Right',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_front_right',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+      'original_icon': 'mdi:car-door-lock',
+      'original_name': 'Door Back Left Lock',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_back_left_lock',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+      'original_icon': 'mdi:car-door-lock',
+      'original_name': 'Door Back Right Lock',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_back_right_lock',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+      'original_icon': 'mdi:car-door-lock',
+      'original_name': 'Door Front Left Lock',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_front_left_lock',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+      'original_icon': 'mdi:car-door-lock',
+      'original_name': 'Door Front Right Lock',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_door_front_right_lock',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_window_back_left',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.WINDOW: 'window'>,
+      'original_icon': None,
+      'original_name': 'Window Back Left',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_window_back_left',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_window_back_right',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.WINDOW: 'window'>,
+      'original_icon': None,
+      'original_name': 'Window Back Right',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_window_back_right',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_window_front_left',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.WINDOW: 'window'>,
+      'original_icon': None,
+      'original_name': 'Window Front Left',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_window_front_left',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_window_front_right',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.WINDOW: 'window'>,
+      'original_icon': None,
+      'original_name': 'Window Front Right',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_window_front_right',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_trunk',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': None,
+      'original_name': 'Front Trunk',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_front_trunk',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+      'original_icon': None,
+      'original_name': 'Front Trunk Lock',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_front_trunk_lock',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': None,
+      'original_name': 'Rear Trunk',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_rear_trunk',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+      'original_icon': None,
+      'original_name': 'Rear Trunk Lock',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_rear_trunk_lock',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_engine_cover',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': None,
+      'original_name': 'Engine Cover',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_engine_cover',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_gear_state',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-parking',
+      'original_name': 'Gear State',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_gear_state',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_sunroof',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+      'original_icon': None,
+      'original_name': 'Sunroof',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_sunroof',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_online',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Online',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_online',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_asleep',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Asleep',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_asleep',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Digital Key Paired',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_digital_key_paired',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Surveillance Enabled',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_surveillance_enabled',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Battery Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_battery_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_charging_voltage',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 0,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+      'original_icon': None,
+      'original_name': 'Charging Voltage',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_voltage',
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_charging_current',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+      'original_icon': None,
+      'original_name': 'Charging Current',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_amperage',
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_charging_power',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+      'original_icon': None,
+      'original_name': 'Charging Power',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_wattage',
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+      'original_icon': None,
+      'original_name': 'Charging Time Remaining',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_time_to_complete',
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_charging_current_max',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 2,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.CURRENT: 'current'>,
+      'original_icon': None,
+      'original_name': 'Charging Current Max',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_amperage_max',
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.PLUG: 'plug'>,
+      'original_icon': None,
+      'original_name': 'Fast Charger Connected',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_charge_fast_charger_present',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_firmware_version',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:chip',
+      'original_name': 'Firmware Version',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_firmware_version',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_last_webhook_received',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+      'original_icon': 'mdi:clock',
+      'original_name': 'Last Webhook Received',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
+      'unit_of_measurement': None,
+    }),
+  ])
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][lock.vw_id_4_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vw_id_4_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'locked',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][number.vw_id_4_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.vw_id_4_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '57',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'VW ID.4 Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'VW ID.4 Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'NOT_CHARGING',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'VW ID.4 Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_engine_oil_life',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'VW ID.4 Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '52891',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '253',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][switch.vw_id_4_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
       'friendly_name': 'VW ID.4 Charging',
       'icon': 'mdi:ev-plug-type2',
     }),

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -344,18 +344,64 @@
     }),
   })
 # ---
-# name: test_standard_setup[unknown_make][binary_sensor.smartcar_784n_charging_cable_plugged_in]
+# name: test_standard_setup[unknown_make][binary_sensor.smartcar_784n_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'Smartcar 784N Charging Cable Plugged In',
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_charging_cable_plugged_in',
+    'entity_id': 'binary_sensor.smartcar_784n_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][binary_sensor.smartcar_784n_front_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][binary_sensor.smartcar_784n_rear_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_rear_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][binary_sensor.smartcar_784n_steering_wheel_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_standard_setup[unknown_make][device]
@@ -387,25 +433,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_standard_setup[unknown_make][device_tracker.smartcar_784n_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2019-10-24T00:43:46+00:00',
-      'friendly_name': 'Smartcar 784N Location',
-      'gps_accuracy': 0,
-      'icon': 'mdi:car',
-      'latitude': 37.4292,
-      'longitude': 122.1381,
-      'source_type': <SourceType.GPS: 'gps'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.smartcar_784n_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup[unknown_make][entities]
@@ -681,112 +708,679 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.smartcar_784n_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_standard_setup[unknown_make][lock.smartcar_784n_door_lock]
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'Smartcar 784N ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.smartcar_784n_door_lock',
+    'entity_id': 'sensor.smartcar_784n_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unlocked',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[unknown_make][sensor.smartcar_784n_battery]
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'Smartcar 784N Battery',
+      'device_class': 'temperature',
+      'friendly_name': 'Smartcar 784N Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_battery',
+    'entity_id': 'sensor.smartcar_784n_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '30',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[unknown_make][sensor.smartcar_784n_charging_status]
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charging Status',
+      'friendly_name': 'Smartcar 784N EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_status',
+    'entity_id': 'sensor.smartcar_784n_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'FULLY_CHARGED',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[unknown_make][sensor.smartcar_784n_last_webhook_received]
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Smartcar 784N Last Webhook Received',
-      'icon': 'mdi:clock',
+      'friendly_name': 'Smartcar 784N EV Drive Unit Status',
+      'icon': 'mdi:cog',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_last_webhook_received',
+    'entity_id': 'sensor.smartcar_784n_ev_drive_unit_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[unknown_make][sensor.smartcar_784n_range]
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_ev_high_voltage_battery_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'Smartcar 784N Range',
-      'icon': 'mdi:map-marker-distance',
+      'friendly_name': 'Smartcar 784N EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_range',
+    'entity_id': 'sensor.smartcar_784n_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '40.5',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[unknown_make][switch.smartcar_784n_charging]
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charging',
-      'icon': 'mdi:ev-plug-type2',
+      'friendly_name': 'Smartcar 784N Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.smartcar_784n_charging',
+    'entity_id': 'sensor.smartcar_784n_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
+# name: test_standard_setup[unknown_make][switch.smartcar_784n_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'device_class': 'plug',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+      'friendly_name': 'Smartcar 784N Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'entity_id': 'switch.smartcar_784n_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][binary_sensor.vw_id_4_cabin_hvac_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][binary_sensor.vw_id_4_rear_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_standard_setup[vw_id_4][device]
@@ -818,26 +1412,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_standard_setup[vw_id_4][device_tracker.vw_id_4_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:52+00:00',
-      'fetched_at': '2025-05-09T17:27:25.401000+00:00',
-      'friendly_name': 'VW ID.4 Location',
-      'gps_accuracy': 0,
-      'icon': 'mdi:car',
-      'latitude': 37.4292,
-      'longitude': 122.1381,
-      'source_type': <SourceType.GPS: 'gps'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.vw_id_4_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup[vw_id_4][entities]
@@ -1113,453 +1687,675 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.vw_id_4_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_standard_setup[vw_id_4][lock.vw_id_4_door_lock]
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.vw_id_4_door_lock',
+    'entity_id': 'sensor.vw_id_4_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[vw_id_4][sensor.vw_id_4_battery]
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'device_class': 'battery',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Battery',
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery',
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '68',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[vw_id_4][sensor.vw_id_4_charging_status]
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Charging Status',
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_status',
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'NOT_CHARGING',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[vw_id_4][sensor.vw_id_4_last_webhook_received]
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'VW ID.4 Last Webhook Received',
-      'icon': 'mdi:clock',
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[vw_id_4][sensor.vw_id_4_range]
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_ev_high_voltage_battery_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'device_class': 'distance',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Range',
-      'icon': 'mdi:map-marker-distance',
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '275',
-  })
-# ---
-# name: test_standard_setup[vw_id_4][switch.vw_id_4_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.vw_id_4_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_asleep',
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_battery_heater_active]
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Battery Heater Active',
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_battery_heater_active',
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_charging_cable_plugged_in]
+# name: test_standard_setup[vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'Smartcar 784N Charging Cable Plugged In',
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_digital_key_paired',
+    'entity_id': 'switch.vw_id_4_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_left]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Back Left',
-      'icon': 'mdi:car-door',
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_left',
+    'entity_id': 'binary_sensor.smartcar_784n_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_left_lock]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_left_lock',
+    'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_right]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Back Right',
-      'icon': 'mdi:car-door',
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_right',
+    'entity_id': 'binary_sensor.smartcar_784n_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_right_lock]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'Smartcar 784N Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_front_right',
+    'entity_id': 'binary_sensor.smartcar_784n_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1595,25 +2391,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][device_tracker.smartcar_784n_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2019-10-24T00:43:46+00:00',
-      'friendly_name': 'Smartcar 784N Location',
-      'gps_accuracy': 0,
-      'icon': 'mdi:car',
-      'latitude': 37.4292,
-      'longitude': 122.1381,
-      'source_type': <SourceType.GPS: 'gps'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.smartcar_784n_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][entities]
@@ -3495,809 +4272,679 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.smartcar_784n_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][lock.smartcar_784n_door_lock]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'Smartcar 784N ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.smartcar_784n_door_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unlocked',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][number.smartcar_784n_charge_limit]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.smartcar_784n_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '80',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'Smartcar 784N Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '30',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_battery_capacity]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'Smartcar 784N Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_battery_capacity',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '70.9',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charge_rate]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'Smartcar 784N Charge Rate',
-      'icon': 'mdi:speedometer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charge_rate',
+    'entity_id': 'sensor.smartcar_784n_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_current]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'Smartcar 784N Charging Current',
+      'device_class': 'temperature',
+      'friendly_name': 'Smartcar 784N Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_current',
+    'entity_id': 'sensor.smartcar_784n_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_current_max]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'Smartcar 784N Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      'friendly_name': 'Smartcar 784N EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_current_max',
+    'entity_id': 'sensor.smartcar_784n_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_power]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Smartcar 784N Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charging Status',
+      'friendly_name': 'Smartcar 784N EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_status',
+    'entity_id': 'sensor.smartcar_784n_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'FULLY_CHARGED',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_time_remaining]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'Smartcar 784N Charging Time Remaining',
+      'friendly_name': 'Smartcar 784N EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_time_remaining',
+    'entity_id': 'sensor.smartcar_784n_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_voltage]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'Smartcar 784N Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'Smartcar 784N Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_voltage',
+    'entity_id': 'sensor.smartcar_784n_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_energy_added]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][switch.smartcar_784n_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'Smartcar 784N Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'Smartcar 784N Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_energy_added',
+    'entity_id': 'switch.smartcar_784n_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_engine_oil_life]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_engine_oil_life',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0.35',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_firmware_version]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Firmware Version',
-      'icon': 'mdi:chip',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_firmware_version',
+    'entity_id': 'binary_sensor.smartcar_784n_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_fuel]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_fuel',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '53.2',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_fuel_percent]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_fuel_percent',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '30',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'Smartcar 784N Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_fuel_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '40.5',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_gear_state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Gear State',
-      'icon': 'mdi:car-brake-parking',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_gear_state',
+    'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_last_webhook_received]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Smartcar 784N Last Webhook Received',
-      'icon': 'mdi:clock',
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'Smartcar 784N Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_low_voltage_battery',
+    'entity_id': 'binary_sensor.smartcar_784n_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_odometer]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2019-10-24T00:43:46+00:00',
-      'device_class': 'distance',
-      'friendly_name': 'Smartcar 784N Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '37829',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'Smartcar 784N Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '40.5',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'Smartcar 784N Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_time_to_complete',
+    'entity_id': 'binary_sensor.smartcar_784n_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2019-10-24T00:43:46+00:00',
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '219.3',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2019-10-24T00:43:46+00:00',
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '219.3',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2019-10-24T00:43:46+00:00',
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '219.3',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2019-10-24T00:43:46+00:00',
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '219.3',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][switch.smartcar_784n_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.smartcar_784n_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_asleep',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_battery_heater_active]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Battery Heater Active',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_battery_heater_active',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_charging_cable_plugged_in]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'Smartcar 784N Charging Cable Plugged In',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_digital_key_paired',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Back Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Back Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'Smartcar 784N Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][device]
@@ -4329,24 +4976,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][device_tracker.smartcar_784n_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Location',
-      'gps_accuracy': 0,
-      'icon': 'mdi:car',
-      'latitude': 37.4292,
-      'longitude': 122.1381,
-      'source_type': <SourceType.GPS: 'gps'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.smartcar_784n_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][entities]
@@ -6228,806 +6857,675 @@
       'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.smartcar_784n_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][lock.smartcar_784n_door_lock]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'Smartcar 784N ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.smartcar_784n_door_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unlocked',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][number.smartcar_784n_charge_limit]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.smartcar_784n_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '80',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'Smartcar 784N Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '30',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_battery_capacity]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'Smartcar 784N Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_battery_capacity',
+    'entity_id': 'sensor.smartcar_784n_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charge_rate]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'Smartcar 784N Charge Rate',
-      'icon': 'mdi:speedometer',
+      'device_class': 'temperature',
+      'friendly_name': 'Smartcar 784N Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charge_rate',
+    'entity_id': 'sensor.smartcar_784n_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_current]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'Smartcar 784N Charging Current',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      'friendly_name': 'Smartcar 784N EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_current',
+    'entity_id': 'sensor.smartcar_784n_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_current_max]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'Smartcar 784N Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_current_max',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_power]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Smartcar 784N Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charging Status',
+      'friendly_name': 'Smartcar 784N EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_status',
+    'entity_id': 'sensor.smartcar_784n_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'FULLY_CHARGED',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_time_remaining]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'Smartcar 784N Charging Time Remaining',
+      'friendly_name': 'Smartcar 784N EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_time_remaining',
+    'entity_id': 'sensor.smartcar_784n_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_voltage]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'Smartcar 784N Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'Smartcar 784N Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_voltage',
+    'entity_id': 'sensor.smartcar_784n_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_energy_added]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][switch.smartcar_784n_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'Smartcar 784N Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'Smartcar 784N Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_energy_added',
+    'entity_id': 'switch.smartcar_784n_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_engine_oil_life]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2025-09-18T23:30:33+00:00',
-      'fetched_at': '2025-09-18T23:39:43.086000+00:00',
-      'friendly_name': 'Smartcar 784N Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_engine_oil_life',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0.0035',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_firmware_version]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Firmware Version',
-      'icon': 'mdi:chip',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_firmware_version',
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_fuel]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_fuel',
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_fuel_percent]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2025-09-18T23:30:33+00:00',
-      'fetched_at': '2025-09-18T23:39:43.086000+00:00',
-      'friendly_name': 'Smartcar 784N Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_fuel_percent',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '30',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'Smartcar 784N Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_fuel_range',
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_gear_state]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Gear State',
-      'icon': 'mdi:car-brake-parking',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_gear_state',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_last_webhook_received]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Smartcar 784N Last Webhook Received',
-      'icon': 'mdi:clock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'Smartcar 784N Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_low_voltage_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_odometer]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'Smartcar 784N Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '37829',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'Smartcar 784N Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'Smartcar 784N Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_time_to_complete',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][switch.smartcar_784n_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.smartcar_784n_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_asleep',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_battery_heater_active]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Battery Heater Active',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_charging_cable_plugged_in]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'device_class': 'plug',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -7063,26 +7561,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][device_tracker.vw_id_4_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:52+00:00',
-      'fetched_at': '2025-05-09T17:27:25.401000+00:00',
-      'friendly_name': 'VW ID.4 Location',
-      'gps_accuracy': 0,
-      'icon': 'mdi:car',
-      'latitude': 37.4292,
-      'longitude': 122.1381,
-      'source_type': <SourceType.GPS: 'gps'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.vw_id_4_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][entities]
@@ -8964,818 +9442,679 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.vw_id_4_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][lock.vw_id_4_door_lock]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.vw_id_4_door_lock',
+    'entity_id': 'sensor.vw_id_4_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][number.vw_id_4_charge_limit]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:55+00:00',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.vw_id_4_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '100',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'device_class': 'battery',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Battery',
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '68',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_battery_capacity]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T17:27:25.114000+00:00',
-      'device_class': 'energy_storage',
-      'fetched_at': '2025-05-09T17:27:25.114000+00:00',
-      'friendly_name': 'VW ID.4 Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery_capacity',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '82',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charge_rate]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'VW ID.4 Charge Rate',
-      'icon': 'mdi:speedometer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_current]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current',
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_current_max]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current_max',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_power]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'VW ID.4 Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Charging Status',
+      'friendly_name': 'VW ID.4 EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_status',
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'NOT_CHARGING',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_time_remaining]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_voltage]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'VW ID.4 Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_energy_added]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_energy_added',
+    'entity_id': 'switch.vw_id_4_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_engine_oil_life]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_engine_oil_life',
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_firmware_version]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Firmware Version',
-      'icon': 'mdi:chip',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_fuel]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel',
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_fuel_percent]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_percent',
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_gear_state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Gear State',
-      'icon': 'mdi:car-brake-parking',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_gear_state',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_last_webhook_received]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'VW ID.4 Last Webhook Received',
-      'icon': 'mdi:clock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_odometer]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:52+00:00',
-      'device_class': 'distance',
-      'fetched_at': '2025-05-09T17:27:25.401000+00:00',
-      'friendly_name': 'VW ID.4 Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '21919',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'device_class': 'distance',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '275',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_time_to_complete',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][switch.vw_id_4_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.vw_id_4_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_asleep',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_battery_heater_active]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Battery Heater Active',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_charging_cable_plugged_in]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
   })
 # ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][device]
@@ -9807,24 +10146,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][device_tracker.vw_id_4_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Location',
-      'gps_accuracy': 0,
-      'icon': 'mdi:car',
-      'latitude': 37.4292,
-      'longitude': 122.1381,
-      'source_type': <SourceType.GPS: 'gps'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.vw_id_4_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][entities]
@@ -11706,800 +12027,675 @@
       'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.vw_id_4_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][lock.vw_id_4_door_lock]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.vw_id_4_door_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'locked',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][number.vw_id_4_charge_limit]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.vw_id_4_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '80',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '57',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_battery_capacity]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'entity_id': 'sensor.vw_id_4_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charge_rate]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'VW ID.4 Charge Rate',
-      'icon': 'mdi:speedometer',
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_current]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current',
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_current_max]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current_max',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_power]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'VW ID.4 Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging Status',
+      'friendly_name': 'VW ID.4 EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_status',
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'NOT_CHARGING',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_time_remaining]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_voltage]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'VW ID.4 Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_energy_added]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_energy_added',
+    'entity_id': 'switch.vw_id_4_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_engine_oil_life]
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_engine_oil_life',
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_firmware_version]
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Firmware Version',
-      'icon': 'mdi:chip',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_fuel]
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel',
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_fuel_percent]
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_percent',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_gear_state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Gear State',
-      'icon': 'mdi:car-brake-parking',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_gear_state',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_last_webhook_received]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'VW ID.4 Last Webhook Received',
-      'icon': 'mdi:clock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_odometer]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '52891',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '253',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_time_to_complete',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][switch.vw_id_4_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.vw_id_4_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_asleep',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Battery Heater Active',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12535,20 +12731,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][device_tracker.vw_id_4_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Location',
-      'icon': 'mdi:car',
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.vw_id_4_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[network_error-vw_id_4][entities]
@@ -14430,800 +14612,675 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.vw_id_4_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_update_errors[network_error-vw_id_4][lock.vw_id_4_door_lock]
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.vw_id_4_door_lock',
+    'entity_id': 'sensor.vw_id_4_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][number.vw_id_4_charge_limit]
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.vw_id_4_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Battery',
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery',
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_battery_capacity]
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charge_rate]
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'VW ID.4 Charge Rate',
-      'icon': 'mdi:speedometer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charge_rate',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_current]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_current_max]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current_max',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_power]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'VW ID.4 Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging Status',
+      'friendly_name': 'VW ID.4 EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_status',
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_voltage]
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'VW ID.4 Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_energy_added]
+# name: test_update_errors[network_error-vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_energy_added',
+    'entity_id': 'switch.vw_id_4_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_engine_oil_life]
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_engine_oil_life',
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_firmware_version]
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Firmware Version',
-      'icon': 'mdi:chip',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_fuel]
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel',
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_fuel_percent]
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_percent',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_gear_state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Gear State',
-      'icon': 'mdi:car-brake-parking',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_gear_state',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_last_webhook_received]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'VW ID.4 Last Webhook Received',
-      'icon': 'mdi:clock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_odometer]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_time_to_complete',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][switch.vw_id_4_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.vw_id_4_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_asleep',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Battery Heater Active',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -15259,20 +15316,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][device_tracker.vw_id_4_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Location',
-      'icon': 'mdi:car',
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.vw_id_4_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[network_proxy_response-vw_id_4][entities]
@@ -17154,800 +17197,675 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.vw_id_4_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][lock.vw_id_4_door_lock]
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.vw_id_4_door_lock',
+    'entity_id': 'sensor.vw_id_4_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][number.vw_id_4_charge_limit]
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.vw_id_4_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Battery',
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery',
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_battery_capacity]
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charge_rate]
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'VW ID.4 Charge Rate',
-      'icon': 'mdi:speedometer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charge_rate',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_current]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_current_max]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current_max',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_power]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'VW ID.4 Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging Status',
+      'friendly_name': 'VW ID.4 EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_status',
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_voltage]
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'VW ID.4 Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_energy_added]
+# name: test_update_errors[network_proxy_response-vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_energy_added',
+    'entity_id': 'switch.vw_id_4_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_engine_oil_life]
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_engine_oil_life',
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_firmware_version]
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Firmware Version',
-      'icon': 'mdi:chip',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_fuel]
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel',
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_fuel_percent]
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_percent',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_gear_state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Gear State',
-      'icon': 'mdi:car-brake-parking',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_gear_state',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_last_webhook_received]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'VW ID.4 Last Webhook Received',
-      'icon': 'mdi:clock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_odometer]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_time_to_complete',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][switch.vw_id_4_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.vw_id_4_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_asleep',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Battery Heater Active',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -17983,20 +17901,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][device_tracker.vw_id_4_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Location',
-      'icon': 'mdi:car',
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.vw_id_4_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[server_error-vw_id_4][entities]
@@ -19878,800 +19782,675 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.vw_id_4_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_update_errors[server_error-vw_id_4][lock.vw_id_4_door_lock]
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.vw_id_4_door_lock',
+    'entity_id': 'sensor.vw_id_4_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][number.vw_id_4_charge_limit]
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.vw_id_4_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Battery',
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery',
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_battery_capacity]
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charge_rate]
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'VW ID.4 Charge Rate',
-      'icon': 'mdi:speedometer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charge_rate',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_current]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_current_max]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current_max',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_power]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'VW ID.4 Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging Status',
+      'friendly_name': 'VW ID.4 EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_status',
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_voltage]
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'VW ID.4 Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_energy_added]
+# name: test_update_errors[server_error-vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_energy_added',
+    'entity_id': 'switch.vw_id_4_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_engine_oil_life]
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_engine_oil_life',
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_firmware_version]
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Firmware Version',
-      'icon': 'mdi:chip',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_fuel]
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel',
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_fuel_percent]
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_percent',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_gear_state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Gear State',
-      'icon': 'mdi:car-brake-parking',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_gear_state',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_last_webhook_received]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'VW ID.4 Last Webhook Received',
-      'icon': 'mdi:clock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_odometer]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_time_to_complete',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][switch.vw_id_4_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.vw_id_4_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_asleep',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Battery Heater Active',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -20707,20 +20486,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][device_tracker.vw_id_4_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Location',
-      'icon': 'mdi:car',
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.vw_id_4_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[unauthorized-vw_id_4][entities]
@@ -22602,447 +22367,615 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.vw_id_4_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_update_errors[unauthorized-vw_id_4][lock.vw_id_4_door_lock]
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.vw_id_4_door_lock',
+    'entity_id': 'sensor.vw_id_4_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[unauthorized-vw_id_4][number.vw_id_4_charge_limit]
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.vw_id_4_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Battery',
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery',
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_battery_capacity]
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charge_rate]
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'VW ID.4 Charge Rate',
-      'icon': 'mdi:speedometer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charge_rate',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_current]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_current_max]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current_max',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_power]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'VW ID.4 Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging Status',
+      'friendly_name': 'VW ID.4 EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_status',
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_voltage]
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'VW ID.4 Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_energy_added]
+# name: test_update_errors[unauthorized-vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_energy_added',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_engine_oil_life]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_engine_oil_life',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_firmware_version]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Firmware Version',
-      'icon': 'mdi:chip',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_firmware_version',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_fuel]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_fuel_percent]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_percent',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_gear_state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Gear State',
-      'icon': 'mdi:car-brake-parking',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_gear_state',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_last_webhook_received]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'VW ID.4 Last Webhook Received',
-      'icon': 'mdi:clock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_odometer]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_time_to_complete',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][switch.vw_id_4_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.vw_id_4_charging',
+    'entity_id': 'switch.vw_id_4_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/snapshots/test_lock.ambr
+++ b/tests/snapshots/test_lock.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_lock[unknown_make-lock-200-success-locked-NoneType-1]
+# name: test_lock[unknown_make-lock-200-success-locked-NoneType-1-v2]
   list([
     tuple(
       'post',
@@ -13,7 +13,19 @@
     ),
   ])
 # ---
-# name: test_lock[unknown_make-lock-401-unauthroized-unlocked-NoneType-1]
+# name: test_lock[unknown_make-lock-200-success-locked-NoneType-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/lock'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_lock[unknown_make-lock-401-unauthroized-unlocked-NoneType-1-v2]
   list([
     tuple(
       'post',
@@ -27,7 +39,19 @@
     ),
   ])
 # ---
-# name: test_lock[unknown_make-lock-409-unreachable-unlocked-NoneType-1]
+# name: test_lock[unknown_make-lock-401-unauthroized-unlocked-NoneType-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/lock'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_lock[unknown_make-lock-409-unreachable-unlocked-NoneType-1-v2]
   list([
     tuple(
       'post',
@@ -41,7 +65,19 @@
     ),
   ])
 # ---
-# name: test_lock[unknown_make-unlock-200-success-unlocked-NoneType-1]
+# name: test_lock[unknown_make-lock-409-unreachable-unlocked-NoneType-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/lock'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_lock[unknown_make-unlock-200-success-unlocked-NoneType-1-v2]
   list([
     tuple(
       'post',
@@ -55,7 +91,19 @@
     ),
   ])
 # ---
-# name: test_lock[unknown_make-unlock-401-unauthroized-unlocked-NoneType-1]
+# name: test_lock[unknown_make-unlock-200-success-unlocked-NoneType-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/unlock'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_lock[unknown_make-unlock-401-unauthroized-unlocked-NoneType-1-v2]
   list([
     tuple(
       'post',
@@ -69,7 +117,19 @@
     ),
   ])
 # ---
-# name: test_lock[unknown_make-unlock-409-unreachable-unlocked-NoneType-1]
+# name: test_lock[unknown_make-unlock-401-unauthroized-unlocked-NoneType-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/unlock'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_lock[unknown_make-unlock-409-unreachable-unlocked-NoneType-1-v2]
   list([
     tuple(
       'post',
@@ -83,7 +143,19 @@
     ),
   ])
 # ---
-# name: test_lock[unknown_make-unlock-500-server-unlocked-NoneType-4]
+# name: test_lock[unknown_make-unlock-409-unreachable-unlocked-NoneType-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/unlock'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_lock[unknown_make-unlock-500-server-unlocked-NoneType-4-v2]
   list([
     tuple(
       'post',
@@ -121,6 +193,42 @@
       dict({
         'action': 'UNLOCK',
       }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_lock[unknown_make-unlock-500-server-unlocked-NoneType-4-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/unlock'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/unlock'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/unlock'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/unlock'),
+      None,
       dict({
         'authorization': 'Bearer mock-token',
       }),

--- a/tests/snapshots/test_number.ambr
+++ b/tests/snapshots/test_number.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_charging_limit[unknown_make-200-success-90-90-NoneType-1]
+# name: test_charging_limit[unknown_make-200-success-90-90-NoneType-1-v2]
   list([
     tuple(
       'post',
@@ -13,7 +13,25 @@
     ),
   ])
 # ---
-# name: test_charging_limit[unknown_make-401-unauthroized-90-80-NoneType-1]
+# name: test_charging_limit[unknown_make-200-success-90-90-NoneType-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/set-limit'),
+      dict({
+        'data': dict({
+          'attributes': dict({
+            'percent': 90.0,
+          }),
+        }),
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_charging_limit[unknown_make-401-unauthroized-90-80-NoneType-1-v2]
   list([
     tuple(
       'post',
@@ -27,7 +45,25 @@
     ),
   ])
 # ---
-# name: test_charging_limit[unknown_make-409-unreachable-90-80-NoneType-1]
+# name: test_charging_limit[unknown_make-401-unauthroized-90-80-NoneType-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/set-limit'),
+      dict({
+        'data': dict({
+          'attributes': dict({
+            'percent': 90.0,
+          }),
+        }),
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_charging_limit[unknown_make-409-unreachable-90-80-NoneType-1-v2]
   list([
     tuple(
       'post',
@@ -41,7 +77,25 @@
     ),
   ])
 # ---
-# name: test_charging_limit[unknown_make-500-server-90-80-NoneType-4]
+# name: test_charging_limit[unknown_make-409-unreachable-90-80-NoneType-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/set-limit'),
+      dict({
+        'data': dict({
+          'attributes': dict({
+            'percent': 90.0,
+          }),
+        }),
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_charging_limit[unknown_make-500-server-90-80-NoneType-4-v2]
   list([
     tuple(
       'post',
@@ -85,11 +139,79 @@
     ),
   ])
 # ---
-# name: test_charging_limit[unknown_make-None-None-110-80-ServiceValidationError-0]
+# name: test_charging_limit[unknown_make-500-server-90-80-NoneType-4-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/set-limit'),
+      dict({
+        'data': dict({
+          'attributes': dict({
+            'percent': 90.0,
+          }),
+        }),
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/set-limit'),
+      dict({
+        'data': dict({
+          'attributes': dict({
+            'percent': 90.0,
+          }),
+        }),
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/set-limit'),
+      dict({
+        'data': dict({
+          'attributes': dict({
+            'percent': 90.0,
+          }),
+        }),
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/set-limit'),
+      dict({
+        'data': dict({
+          'attributes': dict({
+            'percent': 90.0,
+          }),
+        }),
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_charging_limit[unknown_make-None-None-110-80-ServiceValidationError-0-v2]
   list([
   ])
 # ---
-# name: test_charging_limit[unknown_make-None-None-40-80-ServiceValidationError-0]
+# name: test_charging_limit[unknown_make-None-None-110-80-ServiceValidationError-0-v3]
+  list([
+  ])
+# ---
+# name: test_charging_limit[unknown_make-None-None-40-80-ServiceValidationError-0-v2]
+  list([
+  ])
+# ---
+# name: test_charging_limit[unknown_make-None-None-40-80-ServiceValidationError-0-v3]
   list([
   ])
 # ---

--- a/tests/snapshots/test_sensor.ambr
+++ b/tests/snapshots/test_sensor.ambr
@@ -452,6 +452,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -478,6 +492,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -628,6 +659,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -731,6 +818,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -851,6 +952,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -877,6 +1021,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1027,6 +1188,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1131,6 +1348,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1251,6 +1482,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1277,6 +1551,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1427,6 +1718,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1531,6 +1878,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1651,6 +2012,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1677,6 +2081,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1827,6 +2248,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1930,6 +2407,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2050,6 +2541,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2076,6 +2610,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2226,6 +2777,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2330,6 +2937,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2450,6 +3071,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2476,6 +3140,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2626,6 +3307,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2729,6 +3466,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2849,6 +3600,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2875,6 +3669,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3025,6 +3836,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -3129,6 +3996,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3249,6 +4130,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -3277,6 +4201,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3427,6 +4368,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -3530,6 +4527,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3652,6 +4663,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -3678,6 +4732,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3828,6 +4899,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -3935,6 +5062,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4055,6 +5196,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4081,6 +5265,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4231,6 +5432,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4335,6 +5592,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4455,6 +5726,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4483,6 +5797,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.byd_seal_u_dm_i_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'BYD Seal U Dm-i Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4633,6 +5964,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4736,6 +6123,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.byd_seal_u_dm_i_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4858,6 +6259,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4892,6 +6336,23 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '90',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'JAGUAR I-PACE Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_charge_rate]
@@ -5040,6 +6501,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -5149,6 +6666,20 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '100',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_odometer]
@@ -5269,6 +6800,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -5303,6 +6877,23 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '90',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'JAGUAR I-PACE Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_charge_rate]
@@ -5457,6 +7048,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -5568,6 +7215,20 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '82',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_odometer]
@@ -5698,6 +7359,49 @@
     'state': '699.9',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -5730,6 +7434,23 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '82',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'POLESTAR Polestar 2 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_charge_rate]
@@ -5888,6 +7609,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -5993,6 +7770,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.polestar_polestar_2_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -6119,6 +7910,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -6147,6 +7981,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -6297,6 +8148,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -6400,6 +8307,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -6516,6 +8437,35 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/snapshots/test_services.ambr
+++ b/tests/snapshots/test_services.ambr
@@ -1,12 +1,19 @@
 # serializer version: 1
-# name: test_door_closure[invalid_config_entry-unknown_make][api-calls]
+# name: test_door_closure[invalid_config_entry-unknown_make-v2][api-calls]
   list([
   ])
 # ---
-# name: test_door_closure[invalid_config_entry-unknown_make][error]
+# name: test_door_closure[invalid_config_entry-unknown_make-v2][error]
   ServiceValidationError('invalid_config_entry')
 # ---
-# name: test_door_closure[lock_doors-unknown_make][api-calls]
+# name: test_door_closure[invalid_config_entry-unknown_make-v3][api-calls]
+  list([
+  ])
+# ---
+# name: test_door_closure[invalid_config_entry-unknown_make-v3][error]
+  ServiceValidationError('invalid_config_entry')
+# ---
+# name: test_door_closure[lock_doors-unknown_make-v2][api-calls]
   list([
     tuple(
       'post',
@@ -20,7 +27,19 @@
     ),
   ])
 # ---
-# name: test_door_closure[lock_doors_no_vin-unknown_make][api-calls]
+# name: test_door_closure[lock_doors-unknown_make-v3][api-calls]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/lock'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_door_closure[lock_doors_no_vin-unknown_make-v2][api-calls]
   list([
     tuple(
       'post',
@@ -34,7 +53,19 @@
     ),
   ])
 # ---
-# name: test_door_closure[unlock_doors-unknown_make][api-calls]
+# name: test_door_closure[lock_doors_no_vin-unknown_make-v3][api-calls]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/lock'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_door_closure[unlock_doors-unknown_make-v2][api-calls]
   list([
     tuple(
       'post',
@@ -48,7 +79,19 @@
     ),
   ])
 # ---
-# name: test_door_closure[unreachable-unknown_make][api-calls]
+# name: test_door_closure[unlock_doors-unknown_make-v3][api-calls]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/unlock'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_door_closure[unreachable-unknown_make-v2][api-calls]
   list([
     tuple(
       'post',
@@ -62,7 +105,25 @@
     ),
   ])
 # ---
-# name: test_door_closure[unreachable-unknown_make][error]
+# name: test_door_closure[unreachable-unknown_make-v2][error]
+  dict({
+    'code': 409,
+    'reason': '',
+  })
+# ---
+# name: test_door_closure[unreachable-unknown_make-v3][api-calls]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/lock'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_door_closure[unreachable-unknown_make-v3][error]
   dict({
     'code': 409,
     'reason': '',

--- a/tests/snapshots/test_switch.ambr
+++ b/tests/snapshots/test_switch.ambr
@@ -275,6 +275,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-switch][switch.byd_seal_u_dm_i_climate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i Climate',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.byd_seal_u_dm_i_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-switch][switch.jaguar_i_pace_charging]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -291,6 +305,20 @@
     'state': 'on',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-switch][switch.jaguar_i_pace_climate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE Climate',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.jaguar_i_pace_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-vw_id_4-switch][switch.vw_id_4_charging]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -303,5 +331,19 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-switch][switch.vw_id_4_climate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---

--- a/tests/snapshots/test_switch.ambr
+++ b/tests/snapshots/test_switch.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_switch[unknown_make-turn_off-200-success-off-NoneType-1]
+# name: test_switch[unknown_make-turn_off-200-success-off-NoneType-1-v2]
   list([
     tuple(
       'post',
@@ -13,7 +13,19 @@
     ),
   ])
 # ---
-# name: test_switch[unknown_make-turn_off-401-unauthroized-off-NoneType-1]
+# name: test_switch[unknown_make-turn_off-200-success-off-NoneType-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/stop'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_off-401-unauthroized-off-NoneType-1-v2]
   list([
     tuple(
       'post',
@@ -27,7 +39,19 @@
     ),
   ])
 # ---
-# name: test_switch[unknown_make-turn_off-409-unreachable-off-NoneType-1]
+# name: test_switch[unknown_make-turn_off-401-unauthroized-off-NoneType-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/stop'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_off-409-unreachable-off-NoneType-1-v2]
   list([
     tuple(
       'post',
@@ -41,7 +65,19 @@
     ),
   ])
 # ---
-# name: test_switch[unknown_make-turn_off-500-server-off-NoneType-4]
+# name: test_switch[unknown_make-turn_off-409-unreachable-off-NoneType-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/stop'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_off-500-server-off-NoneType-4-v2]
   list([
     tuple(
       'post',
@@ -85,7 +121,43 @@
     ),
   ])
 # ---
-# name: test_switch[unknown_make-turn_off-503-unavailable-off-ClientResponseError-1]
+# name: test_switch[unknown_make-turn_off-500-server-off-NoneType-4-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/stop'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/stop'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/stop'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/stop'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_off-503-unavailable-off-ClientResponseError-1-v2]
   list([
     tuple(
       'post',
@@ -99,7 +171,19 @@
     ),
   ])
 # ---
-# name: test_switch[unknown_make-turn_on-200-success-on-NoneType-1]
+# name: test_switch[unknown_make-turn_off-503-unavailable-off-ClientResponseError-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/stop'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_on-200-success-on-NoneType-1-v2]
   list([
     tuple(
       'post',
@@ -113,7 +197,19 @@
     ),
   ])
 # ---
-# name: test_switch[unknown_make-turn_on-401-unauthroized-off-NoneType-1]
+# name: test_switch[unknown_make-turn_on-200-success-on-NoneType-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/start'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_on-401-unauthroized-off-NoneType-1-v2]
   list([
     tuple(
       'post',
@@ -127,7 +223,19 @@
     ),
   ])
 # ---
-# name: test_switch[unknown_make-turn_on-409-unreachable-off-NoneType-1]
+# name: test_switch[unknown_make-turn_on-401-unauthroized-off-NoneType-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/start'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_on-409-unreachable-off-NoneType-1-v2]
   list([
     tuple(
       'post',
@@ -135,6 +243,18 @@
       dict({
         'action': 'START',
       }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_on-409-unreachable-off-NoneType-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/start'),
+      None,
       dict({
         'authorization': 'Bearer mock-token',
       }),

--- a/tests/test_auth_impl.py
+++ b/tests/test_auth_impl.py
@@ -5,21 +5,37 @@ from custom_components.smartcar.auth_impl import (
     AsyncConfigEntryAuth,
 )
 
+from . import MOCK_API_ENDPOINTS
+
 
 async def test_config_entry_auth():
+    class MockOAuth2Implementation:
+        def __init__(self):
+            self.client_id = "mock-id"
+
     class MockOAuth2Session:
         async def async_ensure_token_valid(self):
             self.token = {"access_token": "mock-token"}
 
     websession = None
+    oauth_impl = MockOAuth2Implementation()
     oauth_session = MockOAuth2Session()
-    auth = AsyncConfigEntryAuth(websession, oauth_session, "mock-host")
+    auth = AsyncConfigEntryAuth(
+        websession,
+        oauth_impl,
+        oauth_session,
+        MOCK_API_ENDPOINTS,
+    )
 
     assert await auth.async_get_access_token() == "mock-token"
+    assert auth.version == "v2"  # based on `mock-id` not starting with `client_`
 
 
 async def test_token_auth():
     websession = None
-    auth = AccessTokenAuthImpl(websession, "mock-token", "mock-host")
+    auth = AccessTokenAuthImpl(
+        websession, "mock-token", MOCK_API_ENDPOINTS, version="v3"
+    )
 
     assert await auth.async_get_access_token() == "mock-token"
+    assert auth.version == "v3"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -5,6 +5,17 @@ from collections.abc import Awaitable, Callable
 from homeassistant.const import Platform
 import pytest
 
+from custom_components.smartcar import binary_sensor as binary_sensor_module
+
+
+def test_hvac_bool_cast() -> None:
+    """Test extraction of HVAC booleans from webhook signal bodies."""
+    assert binary_sensor_module._hvac_bool({"value": True}) is True
+    assert binary_sensor_module._hvac_bool({"value": False}) is False
+    assert binary_sensor_module._hvac_bool({}) is None
+    assert binary_sensor_module._hvac_bool(False) is False  # noqa: FBT003
+    assert binary_sensor_module._hvac_bool(None) is None
+
 
 @pytest.mark.usefixtures("enable_all_entities")
 @pytest.mark.parametrize("platform", [Platform.BINARY_SENSOR])

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -298,7 +298,8 @@ async def _test_full_flow(
         )
         if client_id_version == "v2":
             expected_authorize_client_id = "mock-id"
-        if client_id_version == "v3":
+        else:
+            assert client_id_version == "v3"
             expected_authorize_client_id = "my-app-id"
 
         assert result["type"] is FlowResultType.EXTERNAL_STEP
@@ -350,7 +351,8 @@ async def _test_full_flow(
                 },
             )
             expected_aioclient_mock_calls += 4  # oauth token & 3 for vehicles & info
-        if client_id_version == "v3":
+        else:
+            assert client_id_version == "v3"
             server_access_token = {
                 "refresh_token": None,
                 "access_token": "server-access-token",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -202,6 +202,20 @@ async def test_full_flow(
             },
             {
                 "form_type": FlowResultType.ABORT,
+                "abort_reason": "not_single_user_app",
+                "errors": {},
+            },
+        ),
+        (
+            {"empty_connections"},
+            {},
+            {
+                CONF_APPLICATION_ID: "my-app-id",
+                "use_webhooks": False,
+            },
+            {
+                "form_type": FlowResultType.ABORT,
+                "abort_reason": "no_vehicles",
                 "errors": {},
             },
         ),
@@ -209,6 +223,7 @@ async def test_full_flow(
     ids=[
         "missing_application_id",
         "invalid_user_configuration",
+        "empty_connections",
     ],
 )
 async def test_full_flow_v3_only(
@@ -255,6 +270,7 @@ async def _test_full_flow(
     expected_result = deepcopy(expected_result)
     final_step = expected_result.pop("final_step", None)
     expected_errors = expected_result.pop("errors", None)
+    expected_abort_reason = expected_result.pop("abort_reason", None)
     expected_placeholders = expected_result.pop("description_placeholders", None)
     expected_data = expected_result.pop("data", {})
     expected_form_type = expected_result.pop(
@@ -370,12 +386,15 @@ async def _test_full_flow(
                 OAUTH2_TOKEN,
                 json=server_access_token,
             )
+            connections_fixture = "list_connections"
+            if "multi_user_app" in setup:
+                connections_fixture = "list_connections_with_multiple_users"
+            elif "empty_connections" in setup:
+                connections_fixture = "list_connections_empty"
             aioclient_mock.get(
                 f"{MOCK_API_ENDPOINT}/connections",
                 json=load_json_object_fixture(
-                    f"api/list_connections{
-                        '_with_multiple_users' if 'multi_user_app' in setup else ''
-                    }.json",
+                    f"api/{connections_fixture}.json",
                     DOMAIN,
                 ),
             )
@@ -388,7 +407,11 @@ async def _test_full_flow(
             )
             expected_aioclient_mock_calls += (
                 3  # oauth token & 2 for connections/signals
-                - (1 if "multi_user_app" in setup else 0)
+                - (
+                    1  # the signals request is never made when the flow aborts
+                    if setup & {"multi_user_app", "empty_connections"}
+                    else 0
+                )
             )
 
         with (
@@ -422,6 +445,9 @@ async def _test_full_flow(
     if expected_errors is not None:
         assert result.get("errors", {}) == expected_errors
         assert result["description_placeholders"] == expected_placeholders
+
+        if expected_abort_reason is not None:
+            assert result["reason"] == expected_abort_reason
     else:
         entries = hass.config_entries.async_entries(DOMAIN)
         assert len(entries) == 1

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -47,6 +47,12 @@ REDIRECT_URL = "https://example.com/auth/external/callback"
     [
         (set(), {}, {CONF_APPLICATION_ID: "my-app-id", "use_webhooks": False}, {}),
         (
+            {"missing_vin"},
+            {},
+            {CONF_APPLICATION_ID: "my-app-id", "use_webhooks": False},
+            {},
+        ),
+        (
             set(),
             {},
             {
@@ -132,6 +138,7 @@ REDIRECT_URL = "https://example.com/auth/external/callback"
     ],
     ids=[
         "no_webhooks",
+        "no_webhooks_missing_vin",
         "webhooks",
         "webhooks_missing_token",
         "webhooks_extraneous_token",
@@ -319,7 +326,7 @@ async def _test_full_flow(
         assert resp.headers["content-type"] == "text/html; charset=utf-8"
 
         vehicle_id = "36ab27d0-fd9d-4455-823a-ce30af709ffc"
-        vin = "5YJSA1CN5DFP00101"
+        vin = "5YJSA1CN5DFP00101" if "missing_vin" not in setup else None
 
         if client_id_version == "v2":
             server_access_token = {
@@ -374,7 +381,10 @@ async def _test_full_flow(
             )
             aioclient_mock.get(
                 f"{MOCK_API_ENDPOINT}/vehicles/{vehicle_id}/signals/vehicleidentification-vin",
-                json=load_json_object_fixture("api/get_vin_signal.json", DOMAIN),
+                json=load_json_object_fixture(
+                    f"api/get_vin_signal{'_missing' if 'missing_vin' in setup else ''}.json",
+                    DOMAIN,
+                ),
             )
             expected_aioclient_mock_calls += (
                 3  # oauth token & 2 for connections/signals
@@ -421,6 +431,14 @@ async def _test_full_flow(
         assert config_entry.unique_id == vehicle_id
 
         data = dict(config_entry.data)
+        expected_attrs = {
+            "vin": vin,
+            "make": "TESLA",
+            "model": "Model S",
+            "year": "2014",
+        }
+        if "missing_vin" in setup:
+            expected_attrs.pop("vin")
         assert "token" in data
         del data["token"]["expires_at"]
         assert dict(config_entry.data) == {
@@ -430,14 +448,7 @@ async def _test_full_flow(
                 server_access_token,
                 scopes=requested_scopes,
             ),
-            "vehicles": {
-                vehicle_id: {
-                    "vin": vin,
-                    "make": "TESLA",
-                    "model": "Model S",
-                    "year": "2014",
-                }
-            },
+            "vehicles": {vehicle_id: expected_attrs},
             **(
                 {
                     "user_id": "218eda3b-0656-49a8-8f3d-360cdad07334",
@@ -695,12 +706,6 @@ async def test_token_error(
             HTTPStatus.OK,
             {"vehicles": []},
             "no_vehicles",
-        ),
-        (
-            "/vehicles/{id}/vin",
-            HTTPStatus.OK,
-            {"vin": ""},
-            "unknown",
         ),
     ],
 )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,7 @@
 """Test the Smartcar config flow."""
 
 from contextlib import nullcontext
+from copy import deepcopy
 from http import HTTPStatus
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -12,12 +13,16 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    load_json_object_fixture,
+)
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 from pytest_homeassistant_custom_component.typing import ClientSessionGenerator
 from syrupy.assertion import SnapshotAssertion
 
 from custom_components.smartcar.const import (
+    CONF_APPLICATION_ID,
     CONF_APPLICATION_MANAGEMENT_TOKEN,
     CONF_CLOUDHOOK,
     CONFIGURABLE_SCOPES,
@@ -25,25 +30,33 @@ from custom_components.smartcar.const import (
     DOMAIN,
     OAUTH2_AUTHORIZE,
     OAUTH2_TOKEN,
+    OAUTH2_TOKEN_LEGACY,
     REQUIRED_SCOPES,
 )
+from custom_components.smartcar.types import APIVersion
 
-from . import MOCK_API_ENDPOINT, setup_integration
+from . import MOCK_API_ENDPOINT, MOCK_API_ENDPOINT_LEGACY, setup_integration
 
 REDIRECT_URL = "https://example.com/auth/external/callback"
 
 
+@pytest.mark.parametrize("client_id_version", ["v2", "v3"])
 @pytest.mark.usefixtures("current_request_with_host")
 @pytest.mark.parametrize(
     ("setup", "entry_data", "user_input", "expected_result"),
     [
-        (set(), {}, {"use_webhooks": False}, {}),
+        (set(), {}, {CONF_APPLICATION_ID: "my-app-id", "use_webhooks": False}, {}),
         (
             set(),
             {},
-            {"use_webhooks": True, CONF_APPLICATION_MANAGEMENT_TOKEN: "mock_amt"},
+            {
+                "use_webhooks": True,
+                CONF_APPLICATION_ID: "my-app-id",
+                CONF_APPLICATION_MANAGEMENT_TOKEN: "mock_amt",
+            },
             {
                 "data": {
+                    CONF_APPLICATION_ID: "my-app-id",
                     CONF_APPLICATION_MANAGEMENT_TOKEN: "mock_amt",
                     CONF_CLOUDHOOK: False,
                     CONF_WEBHOOK_ID: "mock_webhook_id",
@@ -53,7 +66,7 @@ REDIRECT_URL = "https://example.com/auth/external/callback"
         (
             set(),
             {},
-            {"use_webhooks": True},
+            {CONF_APPLICATION_ID: "my-app-id", "use_webhooks": True},
             {
                 "final_step": "webhooks",
                 "errors": {
@@ -69,7 +82,11 @@ REDIRECT_URL = "https://example.com/auth/external/callback"
         (
             set(),
             {},
-            {"use_webhooks": False, CONF_APPLICATION_MANAGEMENT_TOKEN: "mock_amt"},
+            {
+                "use_webhooks": False,
+                CONF_APPLICATION_ID: "my-app-id",
+                CONF_APPLICATION_MANAGEMENT_TOKEN: "mock_amt",
+            },
             {
                 "final_step": "webhooks",
                 "errors": {
@@ -85,9 +102,14 @@ REDIRECT_URL = "https://example.com/auth/external/callback"
         (
             {"cloud"},
             {},
-            {"use_webhooks": True, CONF_APPLICATION_MANAGEMENT_TOKEN: "mock_amt"},
+            {
+                "use_webhooks": True,
+                CONF_APPLICATION_ID: "my-app-id",
+                CONF_APPLICATION_MANAGEMENT_TOKEN: "mock_amt",
+            },
             {
                 "data": {
+                    CONF_APPLICATION_ID: "my-app-id",
                     CONF_APPLICATION_MANAGEMENT_TOKEN: "mock_amt",
                     CONF_CLOUDHOOK: True,
                     CONF_WEBHOOK_ID: "mock_webhook_id",
@@ -97,7 +119,11 @@ REDIRECT_URL = "https://example.com/auth/external/callback"
         (
             {"cloud", "cloud_not_connected"},
             {},
-            {"use_webhooks": True, CONF_APPLICATION_MANAGEMENT_TOKEN: "mock_amt"},
+            {
+                "use_webhooks": True,
+                CONF_APPLICATION_ID: "my-app-id",
+                CONF_APPLICATION_MANAGEMENT_TOKEN: "mock_amt",
+            },
             {
                 "form_type": FlowResultType.ABORT,
                 "errors": {},
@@ -122,11 +148,104 @@ async def test_full_flow(
     user_input: dict,
     expected_result: dict,
     mock_smartcar_auth: AsyncMock,
+    client_id_version: APIVersion,
+    snapshot: SnapshotAssertion,
+):
+    await _test_full_flow(
+        hass,
+        hass_client_no_auth,
+        aioclient_mock,
+        setup,
+        entry_data,
+        user_input,
+        expected_result,
+        mock_smartcar_auth,
+        client_id_version,
+        snapshot,
+    )
+
+
+@pytest.mark.parametrize("client_id_version", ["v3"])
+@pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.parametrize(
+    ("setup", "entry_data", "user_input", "expected_result"),
+    [
+        (
+            set(),
+            {},
+            {"use_webhooks": False},
+            {
+                "final_step": "webhooks",
+                "errors": {
+                    "base": "no_application_id",
+                },
+                "description_placeholders": {
+                    "webhook_url": "webhooks-not-enabled",
+                    "smartcar_url": "https://dashboard.smartcar.com/configuration",
+                    "docs_url": "https://github.com/wbyoung/smartcar/#webhooks",
+                },
+            },
+        ),
+        (
+            {"multi_user_app"},
+            {},
+            {
+                CONF_APPLICATION_ID: "my-app-id",
+                "use_webhooks": False,
+            },
+            {
+                "form_type": FlowResultType.ABORT,
+                "errors": {},
+            },
+        ),
+    ],
+    ids=[
+        "missing_application_id",
+        "invalid_user_configuration",
+    ],
+)
+async def test_full_flow_v3_only(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    setup: set[str],
+    entry_data: dict,
+    user_input: dict,
+    expected_result: dict,
+    mock_smartcar_auth: AsyncMock,
+    client_id_version: APIVersion,
+    snapshot: SnapshotAssertion,
+):
+    await _test_full_flow(
+        hass,
+        hass_client_no_auth,
+        aioclient_mock,
+        setup,
+        entry_data,
+        user_input,
+        expected_result,
+        mock_smartcar_auth,
+        client_id_version,
+        snapshot,
+    )
+
+
+async def _test_full_flow(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    setup: set[str],
+    entry_data: dict,
+    user_input: dict,
+    expected_result: dict,
+    mock_smartcar_auth: AsyncMock,
+    client_id_version: APIVersion,
     snapshot: SnapshotAssertion,
 ):
     """Test full flow."""
 
     continue_steps = True
+    expected_result = deepcopy(expected_result)
     final_step = expected_result.pop("final_step", None)
     expected_errors = expected_result.pop("errors", None)
     expected_placeholders = expected_result.pop("description_placeholders", None)
@@ -177,11 +296,16 @@ async def test_full_flow(
                 "redirect_uri": REDIRECT_URL,
             },
         )
+        if client_id_version == "v2":
+            expected_authorize_client_id = "mock-id"
+        if client_id_version == "v3":
+            expected_authorize_client_id = "my-app-id"
 
         assert result["type"] is FlowResultType.EXTERNAL_STEP
         assert result["step_id"] == "auth"
         assert result["url"] == (
-            f"{OAUTH2_AUTHORIZE}?response_type=code&client_id=mock-id"
+            f"{OAUTH2_AUTHORIZE}?response_type=code&"
+            f"client_id={expected_authorize_client_id}"
             f"&redirect_uri={REDIRECT_URL}"
             f"&state={state}"
             "&mode=live"
@@ -195,36 +319,65 @@ async def test_full_flow(
 
         vehicle_id = "36ab27d0-fd9d-4455-823a-ce30af709ffc"
         vin = "5YJSA1CN5DFP00101"
-        server_access_token = {
-            "refresh_token": "server-refresh-token",
-            "access_token": "server-access-token",
-            "type": "Bearer",
-            "expires_in": 60,
-            "scope": " ".join(requested_scopes),
-        }
 
-        aioclient_mock.post(
-            OAUTH2_TOKEN,
-            json=server_access_token,
-        )
-        aioclient_mock.get(
-            f"{MOCK_API_ENDPOINT}/v2.0/vehicles",
-            json={"paging": {"count": 25, "offset": 0}, "vehicles": [vehicle_id]},
-        )
-        aioclient_mock.get(
-            f"{MOCK_API_ENDPOINT}/v2.0/vehicles/{vehicle_id}/vin", json={"vin": vin}
-        )
-        aioclient_mock.get(
-            f"{MOCK_API_ENDPOINT}/v2.0/vehicles/{vehicle_id}",
-            json={
-                "id": vehicle_id,
-                "make": "TESLA",
-                "model": "Model S",
-                "year": "2014",
-            },
-        )
-
-        expected_aioclient_mock_calls += 4  # oauth token & 3 for vehicles & info
+        if client_id_version == "v2":
+            server_access_token = {
+                "refresh_token": "server-refresh-token",
+                "access_token": "server-access-token",
+                "type": "Bearer",
+                "expires_in": 60,
+                "scope": " ".join(requested_scopes),
+            }
+            aioclient_mock.post(
+                OAUTH2_TOKEN_LEGACY,
+                json=server_access_token,
+            )
+            aioclient_mock.get(
+                f"{MOCK_API_ENDPOINT_LEGACY}/vehicles",
+                json={"paging": {"count": 25, "offset": 0}, "vehicles": [vehicle_id]},
+            )
+            aioclient_mock.get(
+                f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle_id}/vin",
+                json={"vin": vin},
+            )
+            aioclient_mock.get(
+                f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle_id}",
+                json={
+                    "id": vehicle_id,
+                    "make": "TESLA",
+                    "model": "Model S",
+                    "year": "2014",
+                },
+            )
+            expected_aioclient_mock_calls += 4  # oauth token & 3 for vehicles & info
+        if client_id_version == "v3":
+            server_access_token = {
+                "refresh_token": None,
+                "access_token": "server-access-token",
+                "token_type": "bearer",
+                "expires_in": 3600,
+            }
+            aioclient_mock.post(
+                OAUTH2_TOKEN,
+                json=server_access_token,
+            )
+            aioclient_mock.get(
+                f"{MOCK_API_ENDPOINT}/connections",
+                json=load_json_object_fixture(
+                    f"api/list_connections{
+                        '_with_multiple_users' if 'multi_user_app' in setup else ''
+                    }.json",
+                    DOMAIN,
+                ),
+            )
+            aioclient_mock.get(
+                f"{MOCK_API_ENDPOINT}/vehicles/{vehicle_id}/signals/vehicleidentification-vin",
+                json=load_json_object_fixture("api/get_vin_signal.json", DOMAIN),
+            )
+            expected_aioclient_mock_calls += (
+                3  # oauth token & 2 for connections/signals
+                - (1 if "multi_user_app" in setup else 0)
+            )
 
         with (
             patch(
@@ -269,6 +422,7 @@ async def test_full_flow(
         assert "token" in data
         del data["token"]["expires_at"]
         assert dict(config_entry.data) == {
+            "application_id": "my-app-id",
             "auth_implementation": "smartcar",
             "token": dict(
                 server_access_token,
@@ -282,6 +436,13 @@ async def test_full_flow(
                     "year": "2014",
                 }
             },
+            **(
+                {
+                    "user_id": "218eda3b-0656-49a8-8f3d-360cdad07334",
+                }
+                if client_id_version == "v3"
+                else {}
+            ),
             **expected_data,
         }
 
@@ -371,19 +532,19 @@ async def test_duplicate_vins_disallowed(
     }
 
     aioclient_mock.post(
-        OAUTH2_TOKEN,
+        OAUTH2_TOKEN_LEGACY,
         json=server_access_token,
     )
     aioclient_mock.get(
-        f"{MOCK_API_ENDPOINT}/v2.0/vehicles",
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles",
         json={"paging": {"count": 25, "offset": 0}, "vehicles": [vehicle["id"]]},
     )
     aioclient_mock.get(
-        f"{MOCK_API_ENDPOINT}/v2.0/vehicles/{vehicle['id']}/vin",
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}/vin",
         json={"vin": vehicle["vin"]},
     )
     aioclient_mock.get(
-        f"{MOCK_API_ENDPOINT}/v2.0/vehicles/{vehicle['id']}",
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}",
         json={"id": vehicle["id"], "make": "TESLA", "model": "Model S", "year": "2014"},
     )
 
@@ -493,7 +654,7 @@ async def test_token_error(
     assert resp.headers["content-type"] == "text/html; charset=utf-8"
 
     aioclient_mock.post(
-        OAUTH2_TOKEN,
+        OAUTH2_TOKEN_LEGACY,
         status=status_code,
     )
 
@@ -614,11 +775,11 @@ async def test_api_error(
     override_attributes = target_endpoint == "/vehicles/{id}"
 
     aioclient_mock.post(
-        OAUTH2_TOKEN,
+        OAUTH2_TOKEN_LEGACY,
         json=server_access_token,
     )
     aioclient_mock.get(
-        f"{MOCK_API_ENDPOINT}/v2.0/vehicles",
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles",
         status=http_status if override_vehicles else 200,
         json=(
             json
@@ -627,12 +788,12 @@ async def test_api_error(
         ),
     )
     aioclient_mock.get(
-        f"{MOCK_API_ENDPOINT}/v2.0/vehicles/{vehicle_id}/vin",
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle_id}/vin",
         status=http_status if override_vin else 200,
         json=json if override_vin else {"vin": vin},
     )
     aioclient_mock.get(
-        f"{MOCK_API_ENDPOINT}/v2.0/vehicles/{vehicle_id}",
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle_id}",
         status=http_status if override_attributes else 200,
         json=(
             json
@@ -767,18 +928,18 @@ async def test_reauth(
     }
 
     aioclient_mock.post(
-        OAUTH2_TOKEN,
+        OAUTH2_TOKEN_LEGACY,
         json=server_access_token,
     )
     aioclient_mock.get(
-        f"{MOCK_API_ENDPOINT}/v2.0/vehicles",
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles",
         json={"paging": {"count": 25, "offset": 0}, "vehicles": [new_vehicle_id]},
     )
     aioclient_mock.get(
-        f"{MOCK_API_ENDPOINT}/v2.0/vehicles/{new_vehicle_id}/vin", json={"vin": vin}
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{new_vehicle_id}/vin", json={"vin": vin}
     )
     aioclient_mock.get(
-        f"{MOCK_API_ENDPOINT}/v2.0/vehicles/{new_vehicle_id}",
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{new_vehicle_id}",
         json={
             "id": new_vehicle_id,
             "make": "TESLA",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -984,6 +984,203 @@ async def test_reauth(
     assert compare_entry_data == expected_entry_data
 
 
+@pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.parametrize("vehicle_fixture", ["vw_id_4"])
+@pytest.mark.parametrize(
+    (
+        "entry_data",
+        "user_input",
+        "new_vehicle_id",
+        "expected_result",
+    ),
+    [
+        (
+            {},
+            {"use_webhooks": False},
+            "a1d50709-3502-4faa-ba43-a5c7565e6a09",
+            {
+                "abort_reason": "reconfigure_successful",
+                "access_token": "updated-access-token",
+                "setup_calls": 1,
+            },
+        ),
+        (
+            {
+                CONF_APPLICATION_MANAGEMENT_TOKEN: "old_mock_amt",
+                CONF_CLOUDHOOK: False,
+                CONF_WEBHOOK_ID: "original_webhook_id",
+            },
+            {"use_webhooks": True, CONF_APPLICATION_MANAGEMENT_TOKEN: "mock_amt"},
+            "a1d50709-3502-4faa-ba43-a5c7565e6a09",
+            {
+                "abort_reason": "reconfigure_successful",
+                "access_token": "updated-access-token",
+                "setup_calls": 1,
+                "entry_data": {
+                    CONF_APPLICATION_MANAGEMENT_TOKEN: "mock_amt",
+                    CONF_CLOUDHOOK: False,
+                    CONF_WEBHOOK_ID: "original_webhook_id",
+                },
+            },
+        ),
+        (
+            {
+                CONF_APPLICATION_MANAGEMENT_TOKEN: "old_mock_amt",
+                CONF_CLOUDHOOK: False,
+                CONF_WEBHOOK_ID: "original_webhook_id",
+            },
+            {"use_webhooks": False},
+            "a1d50709-3502-4faa-ba43-a5c7565e6a09",
+            {
+                "abort_reason": "reconfigure_successful",
+                "access_token": "updated-access-token",
+                "setup_calls": 1,
+            },
+        ),
+        (
+            {},
+            {"use_webhooks": False},
+            "a-different-vehicle-id",
+            {
+                "abort_reason": "wrong_vehicles",
+                "placeholders": {"vins": "VIWP1AB29P15LA85784N"},
+                "access_token": "mock-access-token",
+                "setup_calls": 0,
+            },
+        ),
+    ],
+    ids=[
+        "reconfigure_successful",
+        "reconfigure_keeps_webhook_id",
+        "reconfigure_disables_webhooks",
+        "wrong_vehicles",
+    ],
+)
+async def test_reconfigure(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    vehicle_fixture: str,
+    vehicle_attributes: dict,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_smartcar_auth: AsyncMock,
+    entry_data: dict,
+    user_input: dict,
+    new_vehicle_id: str,
+    expected_result: dict[str, Any],
+) -> None:
+    """Test the reconfiguration flow."""
+    expected_abort_reason = expected_result.get("abort_reason")
+    expected_placeholders = expected_result.get("placeholders")
+    expected_access_token = expected_result.get("access_token")
+    expected_setup_calls = expected_result.get("setup_calls", 1)
+    expected_entry_data = expected_result.get("entry_data", {})
+
+    mock_config_entry.add_to_hass(hass)
+
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        data={**mock_config_entry.data, **entry_data},
+    )
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "webhooks"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "scopes"
+
+    selected_scopes = ["read_odometer"]
+    requested_scopes = REQUIRED_SCOPES + selected_scopes
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {k: k in selected_scopes for k in CONFIGURABLE_SCOPES},
+    )
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT_URL,
+        },
+    )
+
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+    assert result["step_id"] == "auth"
+
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+
+    vin = "5YJSA1CN5DFP00101"
+    server_access_token = {
+        "refresh_token": "mock-refresh-token",
+        "access_token": "updated-access-token",
+        "type": "Bearer",
+        "expires_in": 60,
+        "scope": " ".join(requested_scopes),
+    }
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN_LEGACY,
+        json=server_access_token,
+    )
+    aioclient_mock.get(
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles",
+        json={"paging": {"count": 25, "offset": 0}, "vehicles": [new_vehicle_id]},
+    )
+    aioclient_mock.get(
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{new_vehicle_id}/vin", json={"vin": vin}
+    )
+    aioclient_mock.get(
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{new_vehicle_id}",
+        json={
+            "id": new_vehicle_id,
+            "make": "TESLA",
+            "model": "Model S",
+            "year": "2014",
+        },
+    )
+
+    with (
+        patch(
+            "custom_components.smartcar.async_setup_entry", return_value=True
+        ) as mock_setup,
+        patch(
+            "homeassistant.components.cloud.async_active_subscription",
+            return_value=False,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+        await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert len(mock_setup.mock_calls) == expected_setup_calls
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == expected_abort_reason
+    assert result["description_placeholders"] == expected_placeholders
+
+    assert mock_config_entry.unique_id == vehicle_attributes["id"]
+    assert "token" in mock_config_entry.data
+
+    # limit scope of comparison for config entry data
+    compare_entry_data = {**mock_config_entry.data}
+    token = compare_entry_data.pop("token")
+    compare_entry_data.pop("auth_implementation", None)
+    compare_entry_data.pop("vehicles", None)
+
+    # verify access token is refreshed
+    assert token["access_token"] == expected_access_token
+    assert token["refresh_token"] == "mock-refresh-token"  # noqa: S105
+    assert compare_entry_data == expected_entry_data
+
+
 @pytest.mark.parametrize("vehicle_fixture", ["vw_id_4"])
 @pytest.mark.parametrize(
     ("setup", "entry_data", "user_input", "expected_result"),

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -83,7 +83,7 @@ async def test_restore_device_tracker_save_state(
 
     await setup_integration(hass, mock_config_entry)
 
-    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["vin"]]
+    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["id"]]
     coordinator.data = coordinator_data
 
     await async_mock_restore_state_shutdown_restart(hass)  # trigger saving state
@@ -140,7 +140,7 @@ async def test_restore_state(
 
     await setup_added_integration(hass, mock_config_entry)
 
-    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["vin"]]
+    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["id"]]
     state = hass.states.get(entity_id)
     assert state
     assert state.state == device_tracker_state

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -577,6 +577,21 @@ _SNAPSHOT_ORDER = {
             "charge_fast_charger_present",
             "firmware_version",
             "last_webhook_received",
+            "is_cabin_hvac_active",
+            "diag_abs",
+            "diag_mil",
+            "diag_dtc_count",
+            "diag_dtc_list",
+            "diag_ev_battery_conditioning",
+            "diag_ev_charging",
+            "diag_ev_drive_unit",
+            "diag_ev_hv_battery",
+            "cabin_target_temperature",
+            "is_cabin_hvac_active",
+            "is_front_defroster_active",
+            "is_rear_defroster_active",
+            "is_steering_heater_active",
+            "climate",
         ]
     )
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """Test component setup."""
 
+import logging
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.components import cloud
@@ -14,6 +15,7 @@ from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClien
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props
 
+from custom_components.smartcar import coordinator as coordinator_module
 from custom_components.smartcar.const import (
     CONF_APPLICATION_MANAGEMENT_TOKEN,
     CONF_CLOUDHOOK,
@@ -601,3 +603,29 @@ def snapshot_order(entity):
     _, key = entity.unique_id.split("_", 1)
 
     return _SNAPSHOT_ORDER[key]
+
+
+@pytest.mark.parametrize(
+    ("error_type", "error_code", "expected_level"),
+    [
+        ("VEHICLE_STATE", "NOT_CHARGING", logging.DEBUG),
+        ("COMPATIBILITY", "VEHICLE_NOT_CAPABLE", logging.DEBUG),
+        ("PERMISSION", None, logging.ERROR),
+    ],
+    ids=["not_charging", "not_capable", "genuine_error"],
+)
+def test_webhook_signal_error_log_level(
+    caplog: pytest.LogCaptureFixture,
+    error_type: str,
+    error_code: str | None,
+    expected_level: int,
+) -> None:
+    """Test benign signal errors are demoted to DEBUG while others are not."""
+    with caplog.at_level(logging.DEBUG, logger="custom_components.smartcar"):
+        coordinator_module._handle_webhook_signal_error(
+            "Wattage",
+            {"type": error_type, "code": error_code},
+        )
+
+    record = next(r for r in caplog.records if "error for signal" in r.message)
+    assert record.levelno == expected_level

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -64,6 +64,7 @@ async def test_standard_setup(
         assert hass.states.get(entity.entity_id) == snapshot(name=entity.entity_id)
 
 
+@pytest.mark.parametrize("client_id_version", ["v2", "v3"])
 @pytest.mark.usefixtures("enable_all_entities")
 async def test_standard_setup_with_all_entities(
     hass: HomeAssistant,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -22,6 +22,7 @@ from custom_components.smartcar.const import (
     REQUIRED_SCOPES,
     EntityDescriptionKey,
 )
+from custom_components.smartcar.types import APIVersion
 
 from . import MOCK_API_ENDPOINT_LEGACY, setup_added_integration, setup_integration
 
@@ -36,6 +37,7 @@ async def test_standard_setup(
     mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
     vehicle: AsyncMock,
+    client_id_version: APIVersion,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -43,7 +45,7 @@ async def test_standard_setup(
 
     await setup_integration(hass, mock_config_entry)
 
-    device_id = vehicle["vin"]
+    device_id = vehicle["vin"] if client_id_version == "v2" else vehicle["id"]
     device = device_registry.async_get_device({(DOMAIN, device_id)})
 
     assert device is not None
@@ -71,6 +73,7 @@ async def test_standard_setup_with_all_entities(
     mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
     vehicle: AsyncMock,
+    client_id_version: APIVersion,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -78,7 +81,7 @@ async def test_standard_setup_with_all_entities(
 
     await setup_integration(hass, mock_config_entry)
 
-    device_id = vehicle["vin"]
+    device_id = vehicle["vin"] if client_id_version == "v2" else vehicle["id"]
     device = device_registry.async_get_device({(DOMAIN, device_id)})
 
     assert device is not None
@@ -145,13 +148,14 @@ async def test_limited_scopes(
     mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
     vehicle: AsyncMock,
+    client_id_version: APIVersion,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test setup when only limited scopes are enabled."""
     await setup_integration(hass, mock_config_entry)
 
-    device_id = vehicle["vin"]
+    device_id = vehicle["vin"] if client_id_version == "v2" else vehicle["id"]
     device = device_registry.async_get_device({(DOMAIN, device_id)})
 
     assert device is not None
@@ -190,6 +194,7 @@ async def test_update_errors(
     mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
     vehicle: AsyncMock,
+    client_id_version: APIVersion,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -197,7 +202,7 @@ async def test_update_errors(
 
     await setup_integration(hass, mock_config_entry)
 
-    device_id = vehicle["vin"]
+    device_id = vehicle["vin"] if client_id_version == "v2" else vehicle["id"]
     device = device_registry.async_get_device({(DOMAIN, device_id)})
 
     assert device is not None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -23,7 +23,7 @@ from custom_components.smartcar.const import (
     EntityDescriptionKey,
 )
 
-from . import MOCK_API_ENDPOINT, setup_added_integration, setup_integration
+from . import MOCK_API_ENDPOINT_LEGACY, setup_added_integration, setup_integration
 
 
 async def test_async_setup(hass: HomeAssistant):
@@ -403,16 +403,16 @@ async def test_migration(
     )
 
     aioclient_mock.get(
-        f"{MOCK_API_ENDPOINT}/v2.0/vehicles",
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles",
         json=({"paging": {"count": 25, "offset": 0}, "vehicles": api_vehicle_ids}),
     )
     for vehicle_id in api_vehicle_ids:
         aioclient_mock.get(
-            f"{MOCK_API_ENDPOINT}/v2.0/vehicles/{vehicle_id}/vin",
+            f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle_id}/vin",
             json={"vin": f"mock-vin-for-${vehicle_id}"},
         )
         aioclient_mock.get(
-            f"{MOCK_API_ENDPOINT}/v2.0/vehicles/{vehicle_id}",
+            f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle_id}",
             json=(
                 {
                     "id": vehicle_id,

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -11,7 +11,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 from syrupy.assertion import SnapshotAssertion
 
-from . import MOCK_API_ENDPOINT, setup_integration
+from . import MOCK_API_ENDPOINT_LEGACY, setup_integration
 
 NO_ERROR = None.__class__
 
@@ -55,7 +55,7 @@ async def test_lock(
     assert len(aioclient_mock.mock_calls) == 1
 
     aioclient_mock.post(
-        f"{MOCK_API_ENDPOINT}/v2.0/vehicles/{vehicle['id']}/security",
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}/security",
         status=api_status,
         json={
             "message": "Some message related to the action unused by our code",

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -11,11 +11,14 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 from syrupy.assertion import SnapshotAssertion
 
-from . import MOCK_API_ENDPOINT_LEGACY, setup_integration
+from custom_components.smartcar.types import APIVersion
+
+from . import MOCK_API_ENDPOINT, MOCK_API_ENDPOINT_LEGACY, setup_integration
 
 NO_ERROR = None.__class__
 
 
+@pytest.mark.parametrize("client_id_version", ["v2", "v3"])
 @pytest.mark.parametrize(
     (
         "service_action",
@@ -48,20 +51,40 @@ async def test_lock(
     expected_state: LockState,
     expected_raises: Exception,
     api_calls: int,
+    client_id_version: APIVersion,
 ) -> None:
     """Test locking doors."""
 
     await setup_integration(hass, mock_config_entry)
     assert len(aioclient_mock.mock_calls) == 1
 
-    aioclient_mock.post(
-        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}/security",
-        status=api_status,
-        json={
-            "message": "Some message related to the action unused by our code",
-            "status": api_status_slug,
-        },
-    )
+    if client_id_version == "v2":
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}/security",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
+    else:
+        assert client_id_version == "v3"
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT}/vehicles/{vehicle['id']}/commands/security/lock",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT}/vehicles/{vehicle['id']}/commands/security/unlock",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
 
     try:
         await hass.services.async_call(

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -20,7 +20,7 @@ from pytest_homeassistant_custom_component.common import (
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 from syrupy.assertion import SnapshotAssertion
 
-from . import MOCK_API_ENDPOINT, setup_added_integration, setup_integration
+from . import MOCK_API_ENDPOINT_LEGACY, setup_added_integration, setup_integration
 
 NO_ERROR = None.__class__
 
@@ -66,7 +66,7 @@ async def test_charging_limit(
     assert len(aioclient_mock.mock_calls) == 1
 
     aioclient_mock.post(
-        f"{MOCK_API_ENDPOINT}/v2.0/vehicles/{vehicle['id']}/charge/limit",
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}/charge/limit",
         status=api_status,
         json={
             "message": "Some message related to the action unused by our code",

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -198,7 +198,7 @@ async def test_restore_state_from_v2(
 
     await setup_added_integration(hass, mock_config_entry)
 
-    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["vin"]]
+    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["id"]]
 
     coordinator_data = {
         key: data

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -20,11 +20,19 @@ from pytest_homeassistant_custom_component.common import (
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 from syrupy.assertion import SnapshotAssertion
 
-from . import MOCK_API_ENDPOINT_LEGACY, setup_added_integration, setup_integration
+from custom_components.smartcar.types import APIVersion
+
+from . import (
+    MOCK_API_ENDPOINT,
+    MOCK_API_ENDPOINT_LEGACY,
+    setup_added_integration,
+    setup_integration,
+)
 
 NO_ERROR = None.__class__
 
 
+@pytest.mark.parametrize("client_id_version", ["v2", "v3"])
 @pytest.mark.usefixtures("enable_all_entities")
 @pytest.mark.parametrize(
     (
@@ -57,6 +65,7 @@ async def test_charging_limit(
     expected_state: int,
     expected_raises: Exception,
     api_calls: int,
+    client_id_version: APIVersion,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
@@ -65,14 +74,25 @@ async def test_charging_limit(
     await setup_integration(hass, mock_config_entry)
     assert len(aioclient_mock.mock_calls) == 1
 
-    aioclient_mock.post(
-        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}/charge/limit",
-        status=api_status,
-        json={
-            "message": "Some message related to the action unused by our code",
-            "status": api_status_slug,
-        },
-    )
+    if client_id_version == "v2":
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}/charge/limit",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
+    else:
+        assert client_id_version == "v3"
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT}/vehicles/{vehicle['id']}/commands/charge/set-limit",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
 
     try:
         await hass.services.async_call(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -23,6 +23,7 @@ from pytest_homeassistant_custom_component.common import (
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 from syrupy.assertion import SnapshotAssertion
 
+from custom_components.smartcar import sensor as sensor_module
 from custom_components.smartcar.const import (
     DEFAULT_ENABLED_ENTITY_DESCRIPTION_KEYS,
     OAUTH2_TOKEN_LEGACY,
@@ -40,6 +41,45 @@ from custom_components.smartcar.sensor import SmartcarSensorDescription
 from custom_components.smartcar.types import APIVersion
 
 from . import setup_added_integration, setup_integration
+
+
+def test_diag_status_cast() -> None:
+    """Test extraction of diagnostic statuses from webhook signal bodies."""
+    assert sensor_module._diag_status({"status": "OK"}) == "OK"
+    assert sensor_module._diag_status({"value": "WARNING"}) == "WARNING"
+    assert sensor_module._diag_status({}) is None
+    assert sensor_module._diag_status("OK") == "OK"
+    assert sensor_module._diag_status(None) is None
+
+
+def test_dtc_count_cast() -> None:
+    """Test extraction of trouble code counts from webhook signal bodies."""
+    assert sensor_module._dtc_count({"value": 2}) == 2
+    assert sensor_module._dtc_count({"count": 3}) == 3
+    assert sensor_module._dtc_count({}) is None
+    assert sensor_module._dtc_count(4) == 4
+    assert sensor_module._dtc_count(None) is None
+
+
+def test_dtc_list_cast() -> None:
+    """Test extraction of trouble code lists from webhook signal bodies."""
+    assert (
+        sensor_module._dtc_list({"value": [{"code": "P0100"}, "P0200"]})
+        == "P0100, P0200"
+    )
+    assert sensor_module._dtc_list({"values": ["P0300"]}) == "P0300"
+    assert sensor_module._dtc_list({"codes": ["P0400"]}) == "P0400"
+    assert sensor_module._dtc_list({"value": "P0500"}) == "P0500"
+    assert sensor_module._dtc_list({}) == "none"
+    assert sensor_module._dtc_list(None) is None
+
+
+def test_hvac_number_cast() -> None:
+    """Test extraction of HVAC numbers from webhook signal bodies."""
+    assert sensor_module._hvac_number({"value": 21.5}) == 21.5
+    assert sensor_module._hvac_number({}) is None
+    assert sensor_module._hvac_number(19) == 19
+    assert sensor_module._hvac_number(None) is None
 
 
 @pytest.mark.usefixtures("enable_all_entities")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -37,6 +37,7 @@ from custom_components.smartcar.coordinator import (
 )
 from custom_components.smartcar.entity import SmartcarEntity
 from custom_components.smartcar.sensor import SmartcarSensorDescription
+from custom_components.smartcar.types import APIVersion
 
 from . import setup_added_integration, setup_integration
 
@@ -627,7 +628,7 @@ async def test_restore_sensor_save_state(
 
     await setup_integration(hass, mock_config_entry)
 
-    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["vin"]]
+    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["id"]]
     coordinator.data = coordinator_data
 
     await async_mock_restore_state_shutdown_restart(hass)  # trigger saving state
@@ -680,7 +681,7 @@ async def test_restore_state(
 
     await setup_added_integration(hass, mock_config_entry)
 
-    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["vin"]]
+    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["id"]]
     state = hass.states.get(entity_id)
     assert state
     assert state.state == sensor_state
@@ -787,7 +788,7 @@ async def test_restore_state_from_v2(
 
     await setup_added_integration(hass, mock_config_entry)
 
-    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["vin"]]
+    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["id"]]
 
     coordinator_data = {
         key: data
@@ -814,7 +815,9 @@ async def test_async_update_internals(
 
     @dataclass(kw_only=True)
     class MockCoordinator:
+        vehicle_id: str | None = None
         vin: str | None = None
+        version: APIVersion | None = None
 
     @dataclass(kw_only=True)
     class MockEntityDescription:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -25,7 +25,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from custom_components.smartcar.const import (
     DEFAULT_ENABLED_ENTITY_DESCRIPTION_KEYS,
-    OAUTH2_TOKEN,
+    OAUTH2_TOKEN_LEGACY,
     REQUIRED_SCOPES,
     EntityDescriptionKey,
 )
@@ -473,7 +473,7 @@ async def test_expired_token_update_with_polling_disabled(
     )
 
     aioclient_mock.post(
-        OAUTH2_TOKEN,
+        OAUTH2_TOKEN_LEGACY,
         status=400,
         json={
             "error": "invalid_grant",
@@ -515,7 +515,7 @@ async def test_expired_token_invalid_update_with_polling_disabled(
     )
 
     aioclient_mock.post(
-        OAUTH2_TOKEN,
+        OAUTH2_TOKEN_LEGACY,
         status=500,
         json={
             "error": "server_error",

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -22,7 +22,7 @@ from custom_components.smartcar.services import (
 )
 from custom_components.smartcar.types import SmartcarAPIError
 
-from . import MOCK_API_ENDPOINT, setup_added_integration
+from . import MOCK_API_ENDPOINT_LEGACY, setup_added_integration
 
 NO_ERROR = None.__class__
 
@@ -111,7 +111,7 @@ async def test_door_closure(
     assert len(aioclient_mock.mock_calls) == 0
 
     aioclient_mock.post(
-        f"{MOCK_API_ENDPOINT}/v2.0/vehicles/{vehicle['id']}/security",
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}/security",
         status=api_status,
         json={
             "message": "Some message related to the action unused by our code",

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -20,9 +20,9 @@ from custom_components.smartcar.services import (
     SERVICE_NAME_LOCK_DOORS,
     SERVICE_NAME_UNLOCK_DOORS,
 )
-from custom_components.smartcar.types import SmartcarAPIError
+from custom_components.smartcar.types import APIVersion, SmartcarAPIError
 
-from . import MOCK_API_ENDPOINT_LEGACY, setup_added_integration
+from . import MOCK_API_ENDPOINT, MOCK_API_ENDPOINT_LEGACY, setup_added_integration
 
 NO_ERROR = None.__class__
 
@@ -36,7 +36,7 @@ def test_has_services(
     assert hass.services.has_service(DOMAIN, SERVICE_NAME_UNLOCK_DOORS)
 
 
-# @pytest.mark.parametrize("vehicle_fixture", ["vw_id_4"])
+@pytest.mark.parametrize("client_id_version", ["v2", "v3"])
 @pytest.mark.parametrize("vehicle_fixture", ["unknown_make"])
 @pytest.mark.parametrize(
     "scenario",
@@ -88,6 +88,7 @@ async def test_door_closure(
     aioclient_mock: AiohttpClientMocker,
     scenario: dict[str, Any],
     vehicle: AsyncMock,
+    client_id_version: APIVersion,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ):
@@ -110,14 +111,33 @@ async def test_door_closure(
     await setup_added_integration(hass, mock_config_entry)
     assert len(aioclient_mock.mock_calls) == 0
 
-    aioclient_mock.post(
-        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}/security",
-        status=api_status,
-        json={
-            "message": "Some message related to the action unused by our code",
-            "status": api_status_slug,
-        },
-    )
+    if client_id_version == "v2":
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}/security",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
+    else:
+        assert client_id_version == "v3"
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT}/vehicles/{vehicle['id']}/commands/security/lock",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT}/vehicles/{vehicle['id']}/commands/security/unlock",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
 
     try:
         await hass.services.async_call(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
+    STATE_UNKNOWN,
     Platform,
 )
 from homeassistant.core import HomeAssistant, State
@@ -22,6 +23,7 @@ from pytest_homeassistant_custom_component.common import (
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 from syrupy.assertion import SnapshotAssertion
 
+from custom_components.smartcar import switch as switch_module
 from custom_components.smartcar.types import APIVersion
 
 from . import (
@@ -137,6 +139,105 @@ async def test_switch(
 )
 async def test_webhook_update(webhook_scenario: Callable[[], Awaitable[None]]) -> None:
     await webhook_scenario()
+
+
+def test_hvac_bool_cast() -> None:
+    """Test extraction of HVAC booleans from webhook signal bodies."""
+    assert switch_module._hvac_bool({"value": True}) is True
+    assert switch_module._hvac_bool({"value": False}) is False
+    assert switch_module._hvac_bool({}) is None
+    assert switch_module._hvac_bool(True) is True  # noqa: FBT003
+    assert switch_module._hvac_bool(None) is None
+
+
+@pytest.mark.parametrize("client_id_version", ["v2", "v3"])
+@pytest.mark.parametrize(
+    (
+        "service_action",
+        "api_status",
+        "api_status_slug",
+        "expected_state",
+        "expected_v2_action",
+    ),
+    [
+        (SERVICE_TURN_ON, 200, "success", STATE_ON, "START"),
+        (SERVICE_TURN_OFF, 200, "success", STATE_OFF, "STOP"),
+        (SERVICE_TURN_ON, 409, "unreachable", STATE_UNKNOWN, "START"),
+        (SERVICE_TURN_OFF, 409, "unreachable", STATE_UNKNOWN, "STOP"),
+    ],
+    ids=["turn_on", "turn_off", "turn_on_unreachable", "turn_off_unreachable"],
+)
+@pytest.mark.parametrize("vehicle_fixture", ["unknown_make"])
+async def test_climate_switch(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    aioclient_mock: AiohttpClientMocker,
+    vehicle: AsyncMock,
+    service_action: str,
+    api_status: int,
+    api_status_slug: str,
+    expected_state: str,
+    expected_v2_action: str,
+    client_id_version: APIVersion,
+) -> None:
+    """Test starting/stopping climate (preconditioning)."""
+
+    await setup_integration(hass, mock_config_entry)
+    assert len(aioclient_mock.mock_calls) == 1
+
+    if client_id_version == "v2":
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}/climate",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
+    else:
+        assert client_id_version == "v3"
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT}/vehicles/{vehicle['id']}/commands/climate/start",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT}/vehicles/{vehicle['id']}/commands/climate/stop",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        service_action,
+        {ATTR_ENTITY_ID: "switch.smartcar_784n_climate"},
+        blocking=True,
+    )
+
+    switch_state = hass.states.get("switch.smartcar_784n_climate")
+    assert switch_state.state == expected_state
+
+    assert len(aioclient_mock.mock_calls) == 2
+
+    (method, url, data, _headers) = aioclient_mock.mock_calls[1]
+    expected_subpath = "start" if service_action == SERVICE_TURN_ON else "stop"
+
+    assert method == "POST"
+
+    if client_id_version == "v2":
+        assert str(url).endswith(f"/vehicles/{vehicle['id']}/climate")
+        assert data == {"action": expected_v2_action}
+    else:
+        assert str(url).endswith(
+            f"/vehicles/{vehicle['id']}/commands/climate/{expected_subpath}"
+        )
+        assert data is None
 
 
 RESTORE_STATE_V2_PARAMETRIZE_ARGS = [

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -22,7 +22,7 @@ from pytest_homeassistant_custom_component.common import (
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 from syrupy.assertion import SnapshotAssertion
 
-from . import MOCK_API_ENDPOINT, setup_added_integration, setup_integration
+from . import MOCK_API_ENDPOINT_LEGACY, setup_added_integration, setup_integration
 
 NO_ERROR = None.__class__
 
@@ -67,7 +67,7 @@ async def test_switch(
     assert len(aioclient_mock.mock_calls) == 1
 
     aioclient_mock.post(
-        f"{MOCK_API_ENDPOINT}/v2.0/vehicles/{vehicle['id']}/charge",
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}/charge",
         status=api_status,
         json={
             "message": "Some message related to the action unused by our code",

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -11,7 +11,6 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
-    STATE_UNKNOWN,
     Platform,
 )
 from homeassistant.core import HomeAssistant, State
@@ -162,8 +161,8 @@ def test_hvac_bool_cast() -> None:
     [
         (SERVICE_TURN_ON, 200, "success", STATE_ON, "START"),
         (SERVICE_TURN_OFF, 200, "success", STATE_OFF, "STOP"),
-        (SERVICE_TURN_ON, 409, "unreachable", STATE_UNKNOWN, "START"),
-        (SERVICE_TURN_OFF, 409, "unreachable", STATE_UNKNOWN, "STOP"),
+        (SERVICE_TURN_ON, 409, "unreachable", STATE_OFF, "START"),
+        (SERVICE_TURN_OFF, 409, "unreachable", STATE_OFF, "STOP"),
     ],
     ids=["turn_on", "turn_off", "turn_on_unreachable", "turn_off_unreachable"],
 )
@@ -184,6 +183,16 @@ async def test_climate_switch(
 
     await setup_integration(hass, mock_config_entry)
     assert len(aioclient_mock.mock_calls) == 1
+
+    # seed HVAC data (not present in the vehicle fixture) so the climate
+    # switch becomes available and starts from a known state
+    coordinator = mock_config_entry.runtime_data.coordinators[vehicle["id"]]
+    coordinator.async_set_updated_data(
+        {**(coordinator.data or {}), "hvac-iscabinhvacactive": {"value": False}}
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.smartcar_784n_climate").state == STATE_OFF
 
     if client_id_version == "v2":
         aioclient_mock.post(
@@ -228,7 +237,7 @@ async def test_climate_switch(
     (method, url, data, _headers) = aioclient_mock.mock_calls[1]
     expected_subpath = "start" if service_action == SERVICE_TURN_ON else "stop"
 
-    assert method == "POST"
+    assert method == "post"
 
     if client_id_version == "v2":
         assert str(url).endswith(f"/vehicles/{vehicle['id']}/climate")

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -204,7 +204,7 @@ async def test_restore_state_from_v2(
 
     await setup_added_integration(hass, mock_config_entry)
 
-    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["vin"]]
+    coordinator = mock_config_entry.runtime_data.coordinators[vehicle_attributes["id"]]
 
     coordinator_data = {
         key: data

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -22,11 +22,19 @@ from pytest_homeassistant_custom_component.common import (
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 from syrupy.assertion import SnapshotAssertion
 
-from . import MOCK_API_ENDPOINT_LEGACY, setup_added_integration, setup_integration
+from custom_components.smartcar.types import APIVersion
+
+from . import (
+    MOCK_API_ENDPOINT,
+    MOCK_API_ENDPOINT_LEGACY,
+    setup_added_integration,
+    setup_integration,
+)
 
 NO_ERROR = None.__class__
 
 
+@pytest.mark.parametrize("client_id_version", ["v2", "v3"])
 @pytest.mark.parametrize(
     (
         "service_action",
@@ -60,20 +68,40 @@ async def test_switch(
     expected_state: str,
     expected_raises: Exception,
     api_calls: int,
+    client_id_version: APIVersion,
 ) -> None:
     """Test switching charging on/off."""
 
     await setup_integration(hass, mock_config_entry)
     assert len(aioclient_mock.mock_calls) == 1
 
-    aioclient_mock.post(
-        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}/charge",
-        status=api_status,
-        json={
-            "message": "Some message related to the action unused by our code",
-            "status": api_status_slug,
-        },
-    )
+    if client_id_version == "v2":
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}/charge",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
+    else:
+        assert client_id_version == "v3"
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT}/vehicles/{vehicle['id']}/commands/charge/start",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT}/vehicles/{vehicle['id']}/commands/charge/stop",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
 
     try:
         await hass.services.async_call(


### PR DESCRIPTION
This is an alternative to #112 that allows a more graceful upgrade path for v2 users.

Resolves: #110
Resolves: #114
Resolves: #115

**Changes:**

- Update to use the new endpoints for authentication/vehicle connection and token generation.
- Update the polling implementation to pull from the v3 API with the `sc-user-id` header.
- Update entities that perform vehicle actions to the v3 API with the `sc-user-id` header.
- Add a repair for users to warn users to re-configure the integration with a new v3 setup.

### Obtaining `user_id` Through an API Call

In #112, the required `user_id` is obtained through the response from the "OAuth2" flow as is described [in the _Smartcar Connect_ docs](https://smartcar.com/docs/connect/handle-the-response). This is not, however, the only way to obtain the `uset_id`.

The [Smartcar documentation]([smartcar.com/docs/api-reference/authorization/overview#user-id-userid](http://smartcar.com/docs/api-reference/authorization/overview#user-id-userid)) states:

> The `userId` is a unique identifier within the Smartcar platform representing a specific user’s vehicle connection. You obtain this ID from the Connections API when a user grants access to their vehicle.

It's possible that the reference to the _Connections API_ here is still attempting to call out [_Smartcar Connect_](https://smartcar.com/docs/getting-started/connect-vehicles), the "OAuth2" authentication flow, but _Connections API_ is the exact wording used elsewhere for the actual [API endpoints](https://smartcar.com/docs/api-reference/list-connections).

Advantages:

- This allows the continued use of `my.home-assistant.io` for the OAuth redirect URI. This is a familiar pattern for users and ensures a publicly accessible URI can be provided to Smartcar. Using this site simplifies the documentation as well as support issues as it can be more easily established that the flow up until the point of the redirect is correct.
- It does not require nearly as much custom implementation since it can continue to rely on underlying Home Assistant functionality.

Disadvantages:

- It does not follow the documentations recommendations exactly.
- It does not provide for determining the `user_id` when multiple users are linked to an application. This, however, could be viewed through the lens of being an advantage, though, since we could technically support all connections in an application (if we remove the limitation of apps having a single user that's included in this PR).