### PR TITLE
Add reconfigure flow, diagnostics & climate entities

### DIFF
--- a/custom_components/smartcar/binary_sensor.py
+++ b/custom_components/smartcar/binary_sensor.py
@@ -24,6 +24,17 @@ from .entity import SmartcarEntity, SmartcarEntityDescription
 _LOGGER = logging.getLogger(__name__)
 
 
+def _hvac_bool(body: object) -> object:
+    """Extract a boolean from an HVAC webhook signal body ({"value": bool}).
+
+    Returns:
+        The extracted boolean or the body unchanged.
+    """
+    if isinstance(body, dict):
+        return body.get("value")
+    return body
+
+
 @dataclass(frozen=True, kw_only=True)
 class SmartcarBinarySensorDescription(
     BinarySensorEntityDescription, SmartcarEntityDescription
@@ -294,6 +305,39 @@ SENSOR_TYPES: tuple[BinarySensorEntityDescription, ...] = (
         name="Fast Charger Connected",
         value_key_path="charge-isfastchargerpresent.value",
         device_class=BinarySensorDeviceClass.PLUG,
+    ),
+    # --- Climate status (read_climate) ---
+    SmartcarBinarySensorDescription(
+        key=EntityDescriptionKey.IS_CABIN_HVAC_ACTIVE,
+        name="Cabin HVAC Active",
+        value_key_path="hvac-iscabinhvacactive",
+        value_cast=_hvac_bool,
+        device_class=BinarySensorDeviceClass.RUNNING,
+        icon="mdi:air-conditioner",
+    ),
+    SmartcarBinarySensorDescription(
+        key=EntityDescriptionKey.IS_FRONT_DEFROSTER_ACTIVE,
+        name="Front Defroster Active",
+        value_key_path="hvac-isfrontdefrosteractive",
+        value_cast=_hvac_bool,
+        device_class=BinarySensorDeviceClass.RUNNING,
+        icon="mdi:car-defrost-front",
+    ),
+    SmartcarBinarySensorDescription(
+        key=EntityDescriptionKey.IS_REAR_DEFROSTER_ACTIVE,
+        name="Rear Defroster Active",
+        value_key_path="hvac-isreardefrosteractive",
+        value_cast=_hvac_bool,
+        device_class=BinarySensorDeviceClass.RUNNING,
+        icon="mdi:car-defrost-rear",
+    ),
+    SmartcarBinarySensorDescription(
+        key=EntityDescriptionKey.IS_STEERING_HEATER_ACTIVE,
+        name="Steering Wheel Heater Active",
+        value_key_path="hvac-issteeringheateractive",
+        value_cast=_hvac_bool,
+        device_class=BinarySensorDeviceClass.RUNNING,
+        icon="mdi:steering",
     ),
 )
 

--- a/custom_components/smartcar/config_flow.py
+++ b/custom_components/smartcar/config_flow.py
@@ -170,11 +170,12 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
         )
 
     def _initial_data(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
         if self.source == SOURCE_REAUTH:
-            return self._get_reauth_entry().data
+            result = self._get_reauth_entry().data
         if self.source == SOURCE_RECONFIGURE:
-            return self._get_reconfigure_entry().data
-        return {}
+            result = self._get_reconfigure_entry().data
+        return result
 
     @property
     def selected_scopes(self) -> list[Scope]:

--- a/custom_components/smartcar/config_flow.py
+++ b/custom_components/smartcar/config_flow.py
@@ -8,6 +8,7 @@ from aiohttp import ClientConnectorError, ClientError
 from homeassistant.components import cloud, webhook
 from homeassistant.config_entries import (
     SOURCE_REAUTH,
+    SOURCE_RECONFIGURE,
     ConfigEntry,
     ConfigFlowResult,
     OptionsFlow,
@@ -169,7 +170,11 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
         )
 
     def _initial_data(self) -> dict[str, Any]:
-        return self._get_reauth_entry().data if self.source == SOURCE_REAUTH else {}
+        if self.source == SOURCE_REAUTH:
+            return self._get_reauth_entry().data
+        if self.source == SOURCE_RECONFIGURE:
+            return self._get_reconfigure_entry().data
+        return {}
 
     @property
     def selected_scopes(self) -> list[Scope]:
@@ -269,6 +274,20 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
             return await self.async_step_webhooks()
         return await super().async_step_auth(user_input)
 
+    async def async_step_reconfigure(
+        self,
+        user_input: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of an existing entry.
+
+        Replays the customized flow (webhooks then scopes) before re-running
+        the OAuth authorization so permissions can be changed after setup.
+
+        Returns:
+            The config flow result.
+        """
+        return await self.async_step_user()
+
     async def async_step_reauth(
         self,
         entry_data: Mapping[str, Any],  # noqa: ARG002
@@ -331,10 +350,15 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
 
         await self.async_set_unique_id(unique_id_from_entry_data(data))
 
-        other_vins = vehicle_vins_in_use(
-            self.hass,
-            self._get_reauth_entry() if self.source == SOURCE_REAUTH else None,
+        current_entry = (
+            self._get_reauth_entry()
+            if self.source == SOURCE_REAUTH
+            else self._get_reconfigure_entry()
+            if self.source == SOURCE_RECONFIGURE
+            else None
         )
+
+        other_vins = vehicle_vins_in_use(self.hass, current_entry)
         duplicate_vins = [
             details["vin"]
             for details in data.get("vehicles", {}).values()
@@ -348,8 +372,6 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
             )
 
         if self.source == SOURCE_REAUTH:
-            reauth_entry = self._get_reauth_entry()
-
             self._abort_if_unique_id_mismatch(
                 reason="wrong_vehicles",
                 description_placeholders={
@@ -358,16 +380,27 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
             )
 
             return self.async_update_reload_and_abort(
-                reauth_entry, data={**self._initial_data(), **data}
+                current_entry, data={**self._initial_data(), **data}
             )
 
-        self._abort_if_unique_id_configured()
+        if self.source == SOURCE_RECONFIGURE:
+            self._abort_if_unique_id_mismatch(
+                reason="wrong_vehicles",
+                description_placeholders={
+                    "vins": vins_from_entry_data(self._initial_data())
+                },
+            )
+        else:
+            self._abort_if_unique_id_configured()
 
         # populate webhook details
         if CONF_APPLICATION_MANAGEMENT_TOKEN in data:
             try:
                 webhook_id, webhook_url, cloudhook = await _get_webhook_details(
-                    self.hass
+                    self.hass,
+                    self._initial_data().get(CONF_WEBHOOK_ID)
+                    if self.source == SOURCE_RECONFIGURE
+                    else None,
                 )
             except cloud.CloudNotConnected:
                 return self.async_abort(reason="cloud_not_connected")
@@ -380,6 +413,20 @@ class SmartcarOAuth2FlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):  # ty
                 **description_placeholders,
                 "webhook_url": webhook_url,
             }
+
+        if self.source == SOURCE_RECONFIGURE:
+            reconfigure_data = {**self._initial_data(), **data}
+            if CONF_APPLICATION_MANAGEMENT_TOKEN not in data:
+                # webhooks were disabled during reconfigure; drop stale details
+                reconfigure_data.pop(CONF_APPLICATION_MANAGEMENT_TOKEN, None)
+                reconfigure_data.pop(CONF_WEBHOOK_ID, None)
+                reconfigure_data.pop(CONF_CLOUDHOOK, None)
+
+            return self.async_update_reload_and_abort(
+                current_entry,
+                data=reconfigure_data,
+                reason="reconfigure_successful",
+            )
 
         return self.async_create_entry(
             title=DEFAULT_NAME,

--- a/custom_components/smartcar/const.py
+++ b/custom_components/smartcar/const.py
@@ -43,6 +43,9 @@ class Scope(StrEnum):
     READ_TIRES = auto()
     CONTROL_CHARGE = auto()
     CONTROL_SECURITY = auto()
+    READ_DIAGNOSTICS = auto()
+    READ_CLIMATE = auto()
+    CONTROL_CLIMATE = auto()
 
 
 REQUIRED_SCOPES = [
@@ -61,6 +64,9 @@ DEFAULT_SCOPES = [
     Scope.READ_VEHICLE_INFO,
     Scope.READ_VIN,
     Scope.CONTROL_CHARGE,
+    Scope.READ_DIAGNOSTICS,
+    Scope.READ_CLIMATE,
+    Scope.CONTROL_CLIMATE,
 ]
 
 
@@ -121,6 +127,23 @@ class EntityDescriptionKey(StrEnum):
     CHARGE_FAST_CHARGER_PRESENT = auto()
     FIRMWARE_VERSION = auto()
     LAST_WEBHOOK_RECEIVED = auto()
+    # Diagnostics (requires read_diagnostics)
+    DIAG_ABS = auto()
+    DIAG_MIL = auto()
+    DIAG_DTC_COUNT = auto()
+    DIAG_DTC_LIST = auto()
+    DIAG_EV_BATTERY_CONDITIONING = auto()
+    DIAG_EV_CHARGING = auto()
+    DIAG_EV_DRIVE_UNIT = auto()
+    DIAG_EV_HV_BATTERY = auto()
+    # Climate status (requires read_climate)
+    CABIN_TARGET_TEMPERATURE = auto()
+    IS_CABIN_HVAC_ACTIVE = auto()
+    IS_FRONT_DEFROSTER_ACTIVE = auto()
+    IS_REAR_DEFROSTER_ACTIVE = auto()
+    IS_STEERING_HEATER_ACTIVE = auto()
+    # Climate control (requires read_climate + control_climate)
+    CLIMATE = auto()
 
 
 DEFAULT_ENABLED_ENTITY_DESCRIPTION_KEYS = {
@@ -131,4 +154,18 @@ DEFAULT_ENABLED_ENTITY_DESCRIPTION_KEYS = {
     EntityDescriptionKey.LOCATION,
     EntityDescriptionKey.PLUG_STATUS,
     EntityDescriptionKey.RANGE,
+    EntityDescriptionKey.DIAG_ABS,
+    EntityDescriptionKey.DIAG_MIL,
+    EntityDescriptionKey.DIAG_DTC_COUNT,
+    EntityDescriptionKey.DIAG_DTC_LIST,
+    EntityDescriptionKey.DIAG_EV_BATTERY_CONDITIONING,
+    EntityDescriptionKey.DIAG_EV_CHARGING,
+    EntityDescriptionKey.DIAG_EV_DRIVE_UNIT,
+    EntityDescriptionKey.DIAG_EV_HV_BATTERY,
+    EntityDescriptionKey.CABIN_TARGET_TEMPERATURE,
+    EntityDescriptionKey.IS_CABIN_HVAC_ACTIVE,
+    EntityDescriptionKey.IS_FRONT_DEFROSTER_ACTIVE,
+    EntityDescriptionKey.IS_REAR_DEFROSTER_ACTIVE,
+    EntityDescriptionKey.IS_STEERING_HEATER_ACTIVE,
+    EntityDescriptionKey.CLIMATE,
 }

--- a/custom_components/smartcar/coordinator.py
+++ b/custom_components/smartcar/coordinator.py
@@ -48,6 +48,18 @@ VEHICLE_RIGHT_COLUMN = 1
 
 UPDATE_INTERVAL = timedelta(hours=6)
 
+# Signal error conditions that are structural or otherwise expected for a given
+# vehicle and therefore recur on every update (e.g. a vehicle that is simply not
+# capable of a signal, or charge signals while not charging). Logging these at
+# ERROR floods the log with permanent noise, so they are demoted to DEBUG.
+# Genuine/actionable errors keep their original level.
+_BENIGN_SIGNAL_ERRORS: frozenset[tuple[str | None, str | None]] = frozenset(
+    {
+        ("COMPATIBILITY", "VEHICLE_NOT_CAPABLE"),
+        ("VEHICLE_STATE", "NOT_CHARGING"),
+    }
+)
+
 
 @dataclass
 class DatapointConfig:
@@ -477,6 +489,51 @@ DATAPOINT_ENTITY_KEY_MAP = {
         [],
         None,
         None,
+    ),
+    # Diagnostics (webhook-only, require read_diagnostics)
+    EntityDescriptionKey.DIAG_ABS: DatapointConfig(
+        "diagnostics-abs", ["read_diagnostics"], None, None
+    ),
+    EntityDescriptionKey.DIAG_MIL: DatapointConfig(
+        "diagnostics-mil", ["read_diagnostics"], None, None
+    ),
+    EntityDescriptionKey.DIAG_DTC_COUNT: DatapointConfig(
+        "diagnostics-dtccount", ["read_diagnostics"], None, None
+    ),
+    EntityDescriptionKey.DIAG_DTC_LIST: DatapointConfig(
+        "diagnostics-dtclist", ["read_diagnostics"], None, None
+    ),
+    EntityDescriptionKey.DIAG_EV_BATTERY_CONDITIONING: DatapointConfig(
+        "diagnostics-evbatteryconditioning", ["read_diagnostics"], None, None
+    ),
+    EntityDescriptionKey.DIAG_EV_CHARGING: DatapointConfig(
+        "diagnostics-evcharging", ["read_diagnostics"], None, None
+    ),
+    EntityDescriptionKey.DIAG_EV_DRIVE_UNIT: DatapointConfig(
+        "diagnostics-evdriveunit", ["read_diagnostics"], None, None
+    ),
+    EntityDescriptionKey.DIAG_EV_HV_BATTERY: DatapointConfig(
+        "diagnostics-evhvbattery", ["read_diagnostics"], None, None
+    ),
+    # Climate status (webhook-only, require read_climate)
+    EntityDescriptionKey.CABIN_TARGET_TEMPERATURE: DatapointConfig(
+        "hvac-cabintargettemperature", ["read_climate"], None, None
+    ),
+    EntityDescriptionKey.IS_CABIN_HVAC_ACTIVE: DatapointConfig(
+        "hvac-iscabinhvacactive", ["read_climate"], None, None
+    ),
+    EntityDescriptionKey.IS_FRONT_DEFROSTER_ACTIVE: DatapointConfig(
+        "hvac-isfrontdefrosteractive", ["read_climate"], None, None
+    ),
+    EntityDescriptionKey.IS_REAR_DEFROSTER_ACTIVE: DatapointConfig(
+        "hvac-isreardefrosteractive", ["read_climate"], None, None
+    ),
+    EntityDescriptionKey.IS_STEERING_HEATER_ACTIVE: DatapointConfig(
+        "hvac-issteeringheateractive", ["read_climate"], None, None
+    ),
+    # Climate control switch (reads HVAC-active state, requires control_climate)
+    EntityDescriptionKey.CLIMATE: DatapointConfig(
+        "hvac-iscabinhvacactive", ["read_climate", "control_climate"], None, None
     ),
 }
 
@@ -1001,6 +1058,9 @@ def _handle_webhook_signal_error(
 ) -> None:
     error_type = error.get("type")
     error_code = error.get("code")
+
+    if (error_type, error_code) in _BENIGN_SIGNAL_ERRORS:
+        level = "debug"
 
     logger_method = getattr(_LOGGER, level)
     logger_method("error for signal %s: %s:%s", signal_name, error_type, error_code)

--- a/custom_components/smartcar/sensor.py
+++ b/custom_components/smartcar/sensor.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfPressure,
     UnitOfSpeed,
+    UnitOfTemperature,
     UnitOfTime,
     UnitOfVolume,
 )
@@ -50,6 +51,43 @@ from .entity import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _diag_status(body: object) -> object:
+    """Extract a diagnostic system status string from a webhook signal body.
+
+    Field name is inferred from Smartcar conventions; falls back across the
+    likely keys so it keeps working once real data flows for this vehicle.
+
+    Returns:
+        The extracted status or the body unchanged.
+    """
+    if not isinstance(body, dict):
+        return body
+    return body.get("status") or body.get("value")
+
+
+def _dtc_count(body: object) -> object:
+    if not isinstance(body, dict):
+        return body
+    value = body.get("value")
+    return body.get("count") if value is None else value
+
+
+def _dtc_list(body: object) -> object:
+    if not isinstance(body, dict):
+        return body
+    items = body.get("value") or body.get("values") or body.get("codes") or []
+    if not isinstance(items, list):
+        return str(items)
+    codes = [str(i.get("code", i)) if isinstance(i, dict) else str(i) for i in items]
+    return ", ".join(codes) if codes else "none"
+
+
+def _hvac_number(body: object) -> object:
+    if not isinstance(body, dict):
+        return body
+    return body.get("value")
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -326,6 +364,83 @@ SENSOR_TYPES: tuple[SmartcarSensorDescription, ...] = (
         name="Firmware Version",
         value_key_path="connectivitysoftware-currentfirmwareversion.value",
         icon="mdi:chip",
+    ),
+    # --- Diagnostics (read_diagnostics) ---
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_ABS,
+        name="ABS Status",
+        value_key_path="diagnostics-abs",
+        value_cast=_diag_status,
+        icon="mdi:car-brake-abs",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_MIL,
+        name="Malfunction Indicator Lamp",
+        value_key_path="diagnostics-mil",
+        value_cast=_diag_status,
+        icon="mdi:engine",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_DTC_COUNT,
+        name="Trouble Code Count",
+        value_key_path="diagnostics-dtccount",
+        value_cast=_dtc_count,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:alert-circle",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_DTC_LIST,
+        name="Trouble Codes",
+        value_key_path="diagnostics-dtclist",
+        value_cast=_dtc_list,
+        icon="mdi:format-list-bulleted",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_EV_BATTERY_CONDITIONING,
+        name="EV Battery Conditioning Status",
+        value_key_path="diagnostics-evbatteryconditioning",
+        value_cast=_diag_status,
+        icon="mdi:battery-heart-variant",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_EV_CHARGING,
+        name="EV Charging Status",
+        value_key_path="diagnostics-evcharging",
+        value_cast=_diag_status,
+        icon="mdi:ev-station",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_EV_DRIVE_UNIT,
+        name="EV Drive Unit Status",
+        value_key_path="diagnostics-evdriveunit",
+        value_cast=_diag_status,
+        icon="mdi:cog",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.DIAG_EV_HV_BATTERY,
+        name="EV High Voltage Battery Status",
+        value_key_path="diagnostics-evhvbattery",
+        value_cast=_diag_status,
+        icon="mdi:car-battery",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    # --- Climate status (read_climate) ---
+    SmartcarSensorDescription(
+        key=EntityDescriptionKey.CABIN_TARGET_TEMPERATURE,
+        name="Cabin Target Temperature",
+        value_key_path="hvac-cabintargettemperature",
+        value_cast=_hvac_number,
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        icon="mdi:thermostat",
     ),
 )
 

--- a/custom_components/smartcar/switch.py
+++ b/custom_components/smartcar/switch.py
@@ -13,6 +13,17 @@ from .entity import SmartcarEntity, SmartcarEntityDescription
 _LOGGER = logging.getLogger(__name__)
 
 
+def _hvac_bool(body: object) -> object:
+    """Extract a boolean from an HVAC webhook signal body ({"value": bool}).
+
+    Returns:
+        The extracted boolean or the body unchanged.
+    """
+    if isinstance(body, dict):
+        return body.get("value")
+    return body
+
+
 @dataclass(frozen=True, kw_only=True)
 class SmartcarSwitchDescription(SwitchEntityDescription, SmartcarEntityDescription):
     """Class describing Smartcar switch entities."""
@@ -27,6 +38,16 @@ ENTITY_DESCRIPTIONS: tuple[SwitchEntityDescription, ...] = (
     ),
 )
 
+CLIMATE_ENTITY_DESCRIPTIONS: tuple[SwitchEntityDescription, ...] = (
+    SmartcarSwitchDescription(
+        key=EntityDescriptionKey.CLIMATE,
+        name="Climate",
+        value_key_path="hvac-iscabinhvacactive",
+        value_cast=_hvac_bool,
+        icon="mdi:air-conditioner",
+    ),
+)
+
 
 async def async_setup_entry(  # noqa: RUF029
     hass: HomeAssistant,  # noqa: ARG001
@@ -37,10 +58,16 @@ async def async_setup_entry(  # noqa: RUF029
     coordinators: dict[str, SmartcarVehicleCoordinator] = (
         entry.runtime_data.coordinators
     )
-    entities = [
+    entities: list[SwitchEntity] = [
         SmartcarChargingSwitch(coordinator, description)
         for coordinator in coordinators.values()
         for description in ENTITY_DESCRIPTIONS
+        if coordinator.is_scope_enabled(description.key, verbose=True)
+    ]
+    entities += [
+        SmartcarClimateSwitch(coordinator, description)
+        for coordinator in coordinators.values()
+        for description in CLIMATE_ENTITY_DESCRIPTIONS
         if coordinator.is_scope_enabled(description.key, verbose=True)
     ]
     _LOGGER.info("Adding %s Smartcar switch entities", len(entities))
@@ -82,6 +109,48 @@ class SmartcarChargingSwitch(SmartcarEntity[bool, bool], SwitchEntity):
 
         if version == "v2":
             command = "/charge"
+            payload = {"action": "STOP"}
+
+        if await self._async_send_command(command, payload):
+            self._inject_raw_value(value=False)
+            self.async_write_ha_state()
+
+
+class SmartcarClimateSwitch(SmartcarEntity[bool, bool], SwitchEntity):
+    """Switch entity to start/stop cabin climate (preconditioning)."""
+
+    _attr_has_entity_name = True
+
+    @property
+    def is_on(self) -> bool:
+        return self._extract_value()
+
+    async def async_turn_on(
+        self,
+        **kwargs,  # noqa: ARG002, ANN003
+    ) -> None:
+        version = self.coordinator.auth.version
+        command = "/climate/start"
+        payload = None
+
+        if version == "v2":
+            command = "/climate"
+            payload = {"action": "START"}
+
+        if await self._async_send_command(command, payload):
+            self._inject_raw_value(value=True)
+            self.async_write_ha_state()
+
+    async def async_turn_off(
+        self,
+        **kwargs,  # noqa: ARG002, ANN003
+    ) -> None:
+        version = self.coordinator.auth.version
+        command = "/climate/stop"
+        payload = None
+
+        if version == "v2":
+            command = "/climate"
             payload = {"action": "STOP"}
 
         if await self._async_send_command(command, payload):

--- a/custom_components/smartcar/translations/en.json
+++ b/custom_components/smartcar/translations/en.json
@@ -21,6 +21,7 @@
       "oauth_timeout": "Timeout resolving OAuth token.",
       "oauth_unauthorized": "OAuth authorization error while obtaining access token.",
       "reauth_successful": "Re-authentication was successful",
+      "reconfigure_successful": "Reconfiguration was successful",
       "unknown": "Unexpected error",
       "user_rejected_authorize": "Account linking rejected: {error}",
       "wrong_vehicles": "The vehicles must match the original selections. Choose the vehicles with VIN(s): {vins}."

--- a/tests/snapshots/test_binary_sensor.ambr
+++ b/tests/snapshots/test_binary_sensor.ambr
@@ -27,6 +27,21 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-binary_sensor][binary_sensor.byd_seal_u_dm_i_cabin_hvac_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'BYD Seal U Dm-i Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.byd_seal_u_dm_i_cabin_hvac_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-byd_seal-binary_sensor][binary_sensor.byd_seal_u_dm_i_charging_cable_plugged_in]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -204,6 +219,21 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-binary_sensor][binary_sensor.byd_seal_u_dm_i_front_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'BYD Seal U Dm-i Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.byd_seal_u_dm_i_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-byd_seal-binary_sensor][binary_sensor.byd_seal_u_dm_i_front_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -247,6 +277,21 @@
     'state': 'on',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-binary_sensor][binary_sensor.byd_seal_u_dm_i_rear_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'BYD Seal U Dm-i Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.byd_seal_u_dm_i_rear_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-byd_seal-binary_sensor][binary_sensor.byd_seal_u_dm_i_rear_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -269,6 +314,21 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.byd_seal_u_dm_i_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-binary_sensor][binary_sensor.byd_seal_u_dm_i_steering_wheel_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'BYD Seal U Dm-i Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.byd_seal_u_dm_i_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -378,6 +438,21 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.jaguar_i_pace_battery_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-binary_sensor][binary_sensor.jaguar_i_pace_cabin_hvac_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'JAGUAR I-PACE Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.jaguar_i_pace_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -579,6 +654,21 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-binary_sensor][binary_sensor.jaguar_i_pace_front_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'JAGUAR I-PACE Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.jaguar_i_pace_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-binary_sensor][binary_sensor.jaguar_i_pace_front_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -624,6 +714,21 @@
     'state': 'on',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-binary_sensor][binary_sensor.jaguar_i_pace_rear_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'JAGUAR I-PACE Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.jaguar_i_pace_rear_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-binary_sensor][binary_sensor.jaguar_i_pace_rear_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -654,6 +759,21 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-binary_sensor][binary_sensor.jaguar_i_pace_steering_wheel_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'JAGUAR I-PACE Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.jaguar_i_pace_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-binary_sensor][binary_sensor.jaguar_i_pace_sunroof]
@@ -769,6 +889,21 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.polestar_polestar_2_battery_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-binary_sensor][binary_sensor.polestar_polestar_2_cabin_hvac_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'POLESTAR Polestar 2 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.polestar_polestar_2_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -970,6 +1105,21 @@
     'state': 'off',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-binary_sensor][binary_sensor.polestar_polestar_2_front_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'POLESTAR Polestar 2 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.polestar_polestar_2_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-polestar_2-binary_sensor][binary_sensor.polestar_polestar_2_front_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1015,6 +1165,21 @@
     'state': 'on',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-binary_sensor][binary_sensor.polestar_polestar_2_rear_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'POLESTAR Polestar 2 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.polestar_polestar_2_rear_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-polestar_2-binary_sensor][binary_sensor.polestar_polestar_2_rear_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1045,6 +1210,21 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-binary_sensor][binary_sensor.polestar_polestar_2_steering_wheel_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'POLESTAR Polestar 2 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.polestar_polestar_2_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_webhook_update[vehicle_state_all-polestar_2-binary_sensor][binary_sensor.polestar_polestar_2_sunroof]
@@ -1158,6 +1338,21 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-binary_sensor][binary_sensor.vw_id_4_cabin_hvac_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1339,6 +1534,21 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-binary_sensor][binary_sensor.vw_id_4_front_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-vw_id_4-binary_sensor][binary_sensor.vw_id_4_front_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1380,6 +1590,21 @@
     'state': 'on',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-binary_sensor][binary_sensor.vw_id_4_rear_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-vw_id_4-binary_sensor][binary_sensor.vw_id_4_rear_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1402,6 +1627,21 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-binary_sensor][binary_sensor.vw_id_4_steering_wheel_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/snapshots/test_diagnostics.ambr
+++ b/tests/snapshots/test_diagnostics.ambr
@@ -95,7 +95,7 @@
           'access_token': '**REDACTED**',
           'installed_app_id': '2d474f47-bab5-4438-9d37-478148b9d073',
           'refresh_token': '**REDACTED**',
-          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security',
+          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security read_diagnostics read_climate control_climate',
         }),
         'vehicles': dict({
           'a1d50709-3502-4faa-ba43-a5c7565e6a09': dict({
@@ -237,7 +237,7 @@
           'access_token': '**REDACTED**',
           'installed_app_id': '2d474f47-bab5-4438-9d37-478148b9d073',
           'refresh_token': '**REDACTED**',
-          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security',
+          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security read_diagnostics read_climate control_climate',
         }),
         'vehicles': dict({
           'a1d50709-3502-4faa-ba43-a5c7565e6a09': dict({
@@ -284,7 +284,7 @@
           'access_token': '**REDACTED**',
           'installed_app_id': '2d474f47-bab5-4438-9d37-478148b9d073',
           'refresh_token': '**REDACTED**',
-          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security',
+          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security read_diagnostics read_climate control_climate',
         }),
         'vehicles': dict({
           'a1d50709-3502-4faa-ba43-a5c7565e6a09': dict({
@@ -335,7 +335,7 @@
           'access_token': '**REDACTED**',
           'installed_app_id': '2d474f47-bab5-4438-9d37-478148b9d073',
           'refresh_token': '**REDACTED**',
-          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security',
+          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security read_diagnostics read_climate control_climate',
         }),
         'vehicles': dict({
           'db745230-7f7c-4791-bcaa-185facf371be': dict({
@@ -915,7 +915,7 @@
           'access_token': '**REDACTED**',
           'installed_app_id': '2d474f47-bab5-4438-9d37-478148b9d073',
           'refresh_token': '**REDACTED**',
-          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security',
+          'scopes': 'read_vehicle_info read_vin read_battery read_charge read_engine_oil read_fuel read_location read_odometer read_security read_tires control_charge control_security read_diagnostics read_climate control_climate',
         }),
         'vehicles': dict({
           'db745230-7f7c-4791-bcaa-185facf371be': dict({

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -359,6 +359,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup[unknown_make][binary_sensor.smartcar_784n_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'Smartcar 784N Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_standard_setup[unknown_make][binary_sensor.smartcar_784n_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -433,6 +447,25 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_standard_setup[unknown_make][device_tracker.smartcar_784n_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
+      'friendly_name': 'Smartcar 784N Location',
+      'gps_accuracy': 0,
+      'icon': 'mdi:car',
+      'latitude': 37.4292,
+      'longitude': 122.1381,
+      'source_type': <SourceType.GPS: 'gps'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.smartcar_784n_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup[unknown_make][entities]
@@ -1179,6 +1212,20 @@
     }),
   ])
 # ---
+# name: test_standard_setup[unknown_make][lock.smartcar_784n_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.smartcar_784n_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unlocked',
+  })
+# ---
 # name: test_standard_setup[unknown_make][sensor.smartcar_784n_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1191,6 +1238,22 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Smartcar 784N Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30',
   })
 # ---
 # name: test_standard_setup[unknown_make][sensor.smartcar_784n_cabin_target_temperature]
@@ -1208,6 +1271,20 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'FULLY_CHARGED',
   })
 # ---
 # name: test_standard_setup[unknown_make][sensor.smartcar_784n_ev_battery_conditioning_status]
@@ -1266,6 +1343,21 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Smartcar 784N Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_standard_setup[unknown_make][sensor.smartcar_784n_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1278,6 +1370,23 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '40.5',
   })
 # ---
 # name: test_standard_setup[unknown_make][sensor.smartcar_784n_trouble_code_count]
@@ -1309,6 +1418,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup[unknown_make][switch.smartcar_784n_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.smartcar_784n_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup[unknown_make][switch.smartcar_784n_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1336,6 +1459,22 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'device_class': 'plug',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
   })
 # ---
 # name: test_standard_setup[vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
@@ -1412,6 +1551,26 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_standard_setup[vw_id_4][device_tracker.vw_id_4_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:52+00:00',
+      'fetched_at': '2025-05-09T17:27:25.401000+00:00',
+      'friendly_name': 'VW ID.4 Location',
+      'gps_accuracy': 0,
+      'icon': 'mdi:car',
+      'latitude': 37.4292,
+      'longitude': 122.1381,
+      'source_type': <SourceType.GPS: 'gps'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.vw_id_4_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup[vw_id_4][entities]
@@ -2158,6 +2317,20 @@
     }),
   ])
 # ---
+# name: test_standard_setup[vw_id_4][lock.vw_id_4_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vw_id_4_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup[vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2170,6 +2343,24 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'device_class': 'battery',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '68',
   })
 # ---
 # name: test_standard_setup[vw_id_4][sensor.vw_id_4_cabin_target_temperature]
@@ -2187,6 +2378,22 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'NOT_CHARGING',
   })
 # ---
 # name: test_standard_setup[vw_id_4][sensor.vw_id_4_ev_battery_conditioning_status]
@@ -2245,6 +2452,21 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'VW ID.4 Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_standard_setup[vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2257,6 +2479,25 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'device_class': 'distance',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '275',
   })
 # ---
 # name: test_standard_setup[vw_id_4][sensor.vw_id_4_trouble_code_count]
@@ -2288,6 +2529,22 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup[vw_id_4][switch.vw_id_4_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup[vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2296,6 +2553,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.vw_id_4_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2317,6 +2600,181 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'Smartcar 784N Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'Smartcar 784N Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2326,6 +2784,47 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2347,6 +2846,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2356,6 +2883,89 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.smartcar_784n_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2391,6 +3001,25 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][device_tracker.smartcar_784n_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
+      'friendly_name': 'Smartcar 784N Location',
+      'gps_accuracy': 0,
+      'icon': 'mdi:car',
+      'latitude': 37.4292,
+      'longitude': 122.1381,
+      'source_type': <SourceType.GPS: 'gps'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.smartcar_784n_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][entities]
@@ -4743,6 +5372,39 @@
     }),
   ])
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][lock.smartcar_784n_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.smartcar_784n_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unlocked',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][number.smartcar_784n_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.smartcar_784n_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4755,6 +5417,38 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Smartcar 784N Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'Smartcar 784N Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '70.9',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_cabin_target_temperature]
@@ -4772,6 +5466,150 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'Smartcar 784N Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Smartcar 784N Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Smartcar 784N Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Smartcar 784N Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'FULLY_CHARGED',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Smartcar 784N Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'Smartcar 784N Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'Smartcar 784N Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_engine_oil_life',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.35',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_ev_battery_conditioning_status]
@@ -4830,6 +5668,114 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '53.2',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '40.5',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Smartcar 784N Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Smartcar 784N Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4842,6 +5788,125 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '37829',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '40.5',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Smartcar 784N Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '219.3',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '219.3',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '219.3',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2019-10-24T00:43:46+00:00',
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '219.3',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_trouble_code_count]
@@ -4873,6 +5938,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][switch.smartcar_784n_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.smartcar_784n_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][switch.smartcar_784n_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4881,6 +5960,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.smartcar_784n_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4902,6 +6007,181 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'Smartcar 784N Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'Smartcar 784N Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4911,6 +6191,47 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4932,6 +6253,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'Smartcar 784N Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4945,6 +6294,89 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'Smartcar 784N Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'Smartcar 784N Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_window_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][device]
@@ -4976,6 +6408,24 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][device_tracker.smartcar_784n_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Location',
+      'gps_accuracy': 0,
+      'icon': 'mdi:car',
+      'latitude': 37.4292,
+      'longitude': 122.1381,
+      'source_type': <SourceType.GPS: 'gps'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.smartcar_784n_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][entities]
@@ -7328,6 +8778,39 @@
     }),
   ])
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][lock.smartcar_784n_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.smartcar_784n_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unlocked',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][number.smartcar_784n_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.smartcar_784n_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -7336,6 +8819,38 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.smartcar_784n_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Smartcar 784N Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'Smartcar 784N Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_battery_capacity',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -7357,6 +8872,152 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'Smartcar 784N Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Smartcar 784N Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'Smartcar 784N Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Smartcar 784N Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'FULLY_CHARGED',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Smartcar 784N Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'Smartcar 784N Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'Smartcar 784N Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-09-18T23:30:33+00:00',
+      'fetched_at': '2025-09-18T23:39:43.086000+00:00',
+      'friendly_name': 'Smartcar 784N Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_engine_oil_life',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0035',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_ev_battery_conditioning_status]
@@ -7415,6 +9076,116 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-09-18T23:30:33+00:00',
+      'fetched_at': '2025-09-18T23:39:43.086000+00:00',
+      'friendly_name': 'Smartcar 784N Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Smartcar 784N Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'Smartcar 784N Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -7423,6 +9194,120 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.smartcar_784n_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '37829',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'Smartcar 784N Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'Smartcar 784N Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'Smartcar 784N Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -7458,6 +9343,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][switch.smartcar_784n_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.smartcar_784n_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][switch.smartcar_784n_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -7466,6 +9365,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.smartcar_784n_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -7487,6 +9412,183 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'device_class': 'plug',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -7496,6 +9598,47 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -7517,6 +9660,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -7526,6 +9697,89 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -7561,6 +9815,26 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][device_tracker.vw_id_4_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:52+00:00',
+      'fetched_at': '2025-05-09T17:27:25.401000+00:00',
+      'friendly_name': 'VW ID.4 Location',
+      'gps_accuracy': 0,
+      'icon': 'mdi:car',
+      'latitude': 37.4292,
+      'longitude': 122.1381,
+      'source_type': <SourceType.GPS: 'gps'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.vw_id_4_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][entities]
@@ -9913,6 +12187,41 @@
     }),
   ])
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][lock.vw_id_4_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vw_id_4_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][number.vw_id_4_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:55+00:00',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.vw_id_4_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '100',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -9927,6 +12236,42 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'device_class': 'battery',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '68',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T17:27:25.114000+00:00',
+      'device_class': 'energy_storage',
+      'fetched_at': '2025-05-09T17:27:25.114000+00:00',
+      'friendly_name': 'VW ID.4 Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '82',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -9938,6 +12283,152 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'VW ID.4 Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'VW ID.4 Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'NOT_CHARGING',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'VW ID.4 Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_engine_oil_life',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -10000,6 +12491,114 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'VW ID.4 Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -10008,6 +12607,124 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:52+00:00',
+      'device_class': 'distance',
+      'fetched_at': '2025-05-09T17:27:25.401000+00:00',
+      'friendly_name': 'VW ID.4 Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '21919',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'device_class': 'distance',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '275',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -10043,6 +12760,22 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][switch.vw_id_4_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'age': '2025-05-09T15:40:57+00:00',
+      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
+      'friendly_name': 'VW ID.4 Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -10051,6 +12784,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.vw_id_4_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -10072,6 +12831,181 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -10085,6 +13019,47 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_online',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
   })
 # ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_defroster_active]
@@ -10102,6 +13077,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -10115,6 +13118,89 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
   })
 # ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][device]
@@ -10146,6 +13232,24 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][device_tracker.vw_id_4_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Location',
+      'gps_accuracy': 0,
+      'icon': 'mdi:car',
+      'latitude': 37.4292,
+      'longitude': 122.1381,
+      'source_type': <SourceType.GPS: 'gps'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.vw_id_4_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][entities]
@@ -12498,6 +15602,39 @@
     }),
   ])
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][lock.vw_id_4_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vw_id_4_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'locked',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][number.vw_id_4_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.vw_id_4_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -12506,6 +15643,38 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '57',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery_capacity',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12523,6 +15692,150 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'VW ID.4 Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'VW ID.4 Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'NOT_CHARGING',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'VW ID.4 Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_engine_oil_life',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12585,6 +15898,114 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'VW ID.4 Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -12593,6 +16014,120 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '52891',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '253',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12628,6 +16163,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][switch.vw_id_4_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -12636,6 +16185,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.vw_id_4_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12657,6 +16232,181 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -12666,6 +16416,47 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12687,6 +16478,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -12696,6 +16515,89 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12731,6 +16633,20 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][device_tracker.vw_id_4_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Location',
+      'icon': 'mdi:car',
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.vw_id_4_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[network_error-vw_id_4][entities]
@@ -15083,6 +18999,39 @@
     }),
   ])
 # ---
+# name: test_update_errors[network_error-vw_id_4][lock.vw_id_4_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vw_id_4_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][number.vw_id_4_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.vw_id_4_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -15091,6 +19040,38 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery_capacity',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -15108,6 +19089,150 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'VW ID.4 Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'VW ID.4 Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'VW ID.4 Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_engine_oil_life',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -15170,6 +19295,114 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'VW ID.4 Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -15178,6 +19411,120 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -15213,6 +19560,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_error-vw_id_4][switch.vw_id_4_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_error-vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -15221,6 +19582,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.vw_id_4_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -15242,6 +19629,181 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -15251,6 +19813,47 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -15272,6 +19875,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -15281,6 +19912,89 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -15316,6 +20030,20 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][device_tracker.vw_id_4_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Location',
+      'icon': 'mdi:car',
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.vw_id_4_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[network_proxy_response-vw_id_4][entities]
@@ -17668,6 +22396,39 @@
     }),
   ])
 # ---
+# name: test_update_errors[network_proxy_response-vw_id_4][lock.vw_id_4_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vw_id_4_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][number.vw_id_4_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.vw_id_4_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -17676,6 +22437,38 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery_capacity',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -17693,6 +22486,150 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'VW ID.4 Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'VW ID.4 Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'VW ID.4 Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_engine_oil_life',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -17755,6 +22692,114 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'VW ID.4 Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -17763,6 +22808,120 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -17798,6 +22957,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[network_proxy_response-vw_id_4][switch.vw_id_4_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[network_proxy_response-vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -17806,6 +22979,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.vw_id_4_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -17827,6 +23026,181 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -17836,6 +23210,47 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -17857,6 +23272,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -17866,6 +23309,89 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -17901,6 +23427,20 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][device_tracker.vw_id_4_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Location',
+      'icon': 'mdi:car',
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.vw_id_4_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[server_error-vw_id_4][entities]
@@ -20253,6 +25793,39 @@
     }),
   ])
 # ---
+# name: test_update_errors[server_error-vw_id_4][lock.vw_id_4_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vw_id_4_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][number.vw_id_4_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.vw_id_4_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -20261,6 +25834,38 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery_capacity',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -20278,6 +25883,150 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'VW ID.4 Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'VW ID.4 Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'VW ID.4 Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_engine_oil_life',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -20340,6 +26089,114 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'VW ID.4 Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -20348,6 +26205,120 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -20383,6 +26354,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[server_error-vw_id_4][switch.vw_id_4_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[server_error-vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -20391,6 +26376,32 @@
     }),
     'context': <ANY>,
     'entity_id': 'switch.vw_id_4_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_asleep]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Asleep',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Battery Heater Active',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -20412,6 +26423,181 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Digital Key Paired',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Back Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Back Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Left',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Left Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Door Front Right',
+      'icon': 'mdi:car-door',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Door Front Right Lock',
+      'icon': 'mdi:car-door-lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_engine_cover]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Engine Cover',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'plug',
+      'friendly_name': 'VW ID.4 Fast Charger Connected',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -20421,6 +26607,47 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_front_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Front Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Front Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_online]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Online',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_online',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -20442,6 +26669,34 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Rear Trunk',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'lock',
+      'friendly_name': 'VW ID.4 Rear Trunk Lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -20451,6 +26706,89 @@
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_sunroof]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'door',
+      'friendly_name': 'VW ID.4 Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Surveillance Enabled',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Back Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'window',
+      'friendly_name': 'VW ID.4 Window Front Right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -20486,6 +26824,20 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][device_tracker.vw_id_4_location]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Location',
+      'icon': 'mdi:car',
+    }),
+    'context': <ANY>,
+    'entity_id': 'device_tracker.vw_id_4_location',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[unauthorized-vw_id_4][entities]
@@ -22838,6 +29190,39 @@
     }),
   ])
 # ---
+# name: test_update_errors[unauthorized-vw_id_4][lock.vw_id_4_door_lock]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Door Lock',
+      'supported_features': <LockEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'lock.vw_id_4_door_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][number.vw_id_4_charge_limit]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charge Limit',
+      'icon': 'mdi:battery-charging-80',
+      'max': 100.0,
+      'min': 50.0,
+      'mode': <NumberMode.BOX: 'box'>,
+      'step': 1.0,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.vw_id_4_charge_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -22846,6 +29231,38 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_battery_capacity]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Battery Capacity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_battery_capacity',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -22863,6 +29280,150 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charge_rate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'speed',
+      'friendly_name': 'VW ID.4 Charge Rate',
+      'icon': 'mdi:speedometer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_current]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_current_max]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'current',
+      'friendly_name': 'VW ID.4 Charging Current Max',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_current_max',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_power]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'VW ID.4 Charging Power',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_power',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_voltage]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'voltage',
+      'friendly_name': 'VW ID.4 Charging Voltage',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_energy_added]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy_storage',
+      'friendly_name': 'VW ID.4 Energy Added',
+      'icon': 'mdi:lightning-bolt',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_energy_added',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_engine_oil_life]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Engine Oil Life',
+      'icon': 'mdi:oil-level',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_engine_oil_life',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -22925,6 +29486,114 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_firmware_version]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Firmware Version',
+      'icon': 'mdi:chip',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_fuel]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_fuel_percent]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Fuel Percent',
+      'icon': 'mdi:gas-station',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_percent',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_fuel_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Fuel Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_fuel_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_gear_state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Gear State',
+      'icon': 'mdi:car-brake-parking',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_gear_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_last_webhook_received]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'VW ID.4 Last Webhook Received',
+      'icon': 'mdi:clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_low_voltage_battery]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'battery',
+      'friendly_name': 'VW ID.4 Low Voltage Battery',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -22933,6 +29602,120 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_odometer]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Odometer',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_odometer',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_range]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'distance',
+      'friendly_name': 'VW ID.4 Range',
+      'icon': 'mdi:map-marker-distance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_range',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_time_to_complete]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'duration',
+      'friendly_name': 'VW ID.4 Time to Complete',
+      'icon': 'mdi:timer',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_time_to_complete',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'pressure',
+      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -22962,6 +29745,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][switch.vw_id_4_charging]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Charging',
+      'icon': 'mdi:ev-plug-type2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_charging',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -344,18 +344,64 @@
     }),
   })
 # ---
-# name: test_standard_setup[unknown_make][binary_sensor.smartcar_784n_charging_cable_plugged_in]
+# name: test_standard_setup[unknown_make][binary_sensor.smartcar_784n_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'Smartcar 784N Charging Cable Plugged In',
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_charging_cable_plugged_in',
+    'entity_id': 'binary_sensor.smartcar_784n_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][binary_sensor.smartcar_784n_front_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][binary_sensor.smartcar_784n_rear_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_rear_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][binary_sensor.smartcar_784n_steering_wheel_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.smartcar_784n_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_standard_setup[unknown_make][device]
@@ -387,25 +433,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_standard_setup[unknown_make][device_tracker.smartcar_784n_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2019-10-24T00:43:46+00:00',
-      'friendly_name': 'Smartcar 784N Location',
-      'gps_accuracy': 0,
-      'icon': 'mdi:car',
-      'latitude': 37.4292,
-      'longitude': 122.1381,
-      'source_type': <SourceType.GPS: 'gps'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.smartcar_784n_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup[unknown_make][entities]
@@ -681,112 +708,679 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.smartcar_784n_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_standard_setup[unknown_make][lock.smartcar_784n_door_lock]
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'Smartcar 784N ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.smartcar_784n_door_lock',
+    'entity_id': 'sensor.smartcar_784n_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unlocked',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[unknown_make][sensor.smartcar_784n_battery]
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'Smartcar 784N Battery',
+      'device_class': 'temperature',
+      'friendly_name': 'Smartcar 784N Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_battery',
+    'entity_id': 'sensor.smartcar_784n_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '30',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[unknown_make][sensor.smartcar_784n_charging_status]
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charging Status',
+      'friendly_name': 'Smartcar 784N EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_status',
+    'entity_id': 'sensor.smartcar_784n_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'FULLY_CHARGED',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[unknown_make][sensor.smartcar_784n_last_webhook_received]
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Smartcar 784N Last Webhook Received',
-      'icon': 'mdi:clock',
+      'friendly_name': 'Smartcar 784N EV Drive Unit Status',
+      'icon': 'mdi:cog',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_last_webhook_received',
+    'entity_id': 'sensor.smartcar_784n_ev_drive_unit_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[unknown_make][sensor.smartcar_784n_range]
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_ev_high_voltage_battery_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'Smartcar 784N Range',
-      'icon': 'mdi:map-marker-distance',
+      'friendly_name': 'Smartcar 784N EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_range',
+    'entity_id': 'sensor.smartcar_784n_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '40.5',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[unknown_make][switch.smartcar_784n_charging]
+# name: test_standard_setup[unknown_make][sensor.smartcar_784n_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charging',
-      'icon': 'mdi:ev-plug-type2',
+      'friendly_name': 'Smartcar 784N Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.smartcar_784n_charging',
+    'entity_id': 'sensor.smartcar_784n_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
+# name: test_standard_setup[unknown_make][switch.smartcar_784n_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'device_class': 'plug',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
+      'friendly_name': 'Smartcar 784N Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
+    'entity_id': 'switch.smartcar_784n_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][binary_sensor.vw_id_4_cabin_hvac_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][binary_sensor.vw_id_4_rear_defroster_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_standard_setup[vw_id_4][device]
@@ -818,26 +1412,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_standard_setup[vw_id_4][device_tracker.vw_id_4_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:52+00:00',
-      'fetched_at': '2025-05-09T17:27:25.401000+00:00',
-      'friendly_name': 'VW ID.4 Location',
-      'gps_accuracy': 0,
-      'icon': 'mdi:car',
-      'latitude': 37.4292,
-      'longitude': 122.1381,
-      'source_type': <SourceType.GPS: 'gps'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.vw_id_4_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup[vw_id_4][entities]
@@ -1113,453 +1687,675 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.vw_id_4_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_standard_setup[vw_id_4][lock.vw_id_4_door_lock]
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.vw_id_4_door_lock',
+    'entity_id': 'sensor.vw_id_4_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[vw_id_4][sensor.vw_id_4_battery]
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'device_class': 'battery',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Battery',
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery',
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '68',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[vw_id_4][sensor.vw_id_4_charging_status]
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Charging Status',
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_status',
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'NOT_CHARGING',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[vw_id_4][sensor.vw_id_4_last_webhook_received]
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'VW ID.4 Last Webhook Received',
-      'icon': 'mdi:clock',
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_last_webhook_received',
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup[vw_id_4][sensor.vw_id_4_range]
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_ev_high_voltage_battery_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'device_class': 'distance',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Range',
-      'icon': 'mdi:map-marker-distance',
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '275',
-  })
-# ---
-# name: test_standard_setup[vw_id_4][switch.vw_id_4_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.vw_id_4_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_asleep',
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_battery_heater_active]
+# name: test_standard_setup[vw_id_4][sensor.vw_id_4_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Battery Heater Active',
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_battery_heater_active',
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_charging_cable_plugged_in]
+# name: test_standard_setup[vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'Smartcar 784N Charging Cable Plugged In',
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_digital_key_paired',
+    'entity_id': 'switch.vw_id_4_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_left]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Back Left',
-      'icon': 'mdi:car-door',
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_left',
+    'entity_id': 'binary_sensor.smartcar_784n_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_left_lock]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_left_lock',
+    'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_right]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Back Right',
-      'icon': 'mdi:car-door',
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_right',
+    'entity_id': 'binary_sensor.smartcar_784n_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_back_right_lock]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'Smartcar 784N Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][binary_sensor.smartcar_784n_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_front_right',
+    'entity_id': 'binary_sensor.smartcar_784n_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1595,25 +2391,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][device_tracker.smartcar_784n_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2019-10-24T00:43:46+00:00',
-      'friendly_name': 'Smartcar 784N Location',
-      'gps_accuracy': 0,
-      'icon': 'mdi:car',
-      'latitude': 37.4292,
-      'longitude': 122.1381,
-      'source_type': <SourceType.GPS: 'gps'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.smartcar_784n_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v2][entities]
@@ -3495,809 +4272,679 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.smartcar_784n_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][lock.smartcar_784n_door_lock]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'Smartcar 784N ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.smartcar_784n_door_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unlocked',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][number.smartcar_784n_charge_limit]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.smartcar_784n_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '80',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'Smartcar 784N Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '30',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_battery_capacity]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'Smartcar 784N Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_battery_capacity',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '70.9',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charge_rate]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'Smartcar 784N Charge Rate',
-      'icon': 'mdi:speedometer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charge_rate',
+    'entity_id': 'sensor.smartcar_784n_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_current]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'Smartcar 784N Charging Current',
+      'device_class': 'temperature',
+      'friendly_name': 'Smartcar 784N Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_current',
+    'entity_id': 'sensor.smartcar_784n_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_current_max]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'Smartcar 784N Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      'friendly_name': 'Smartcar 784N EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_current_max',
+    'entity_id': 'sensor.smartcar_784n_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_power]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Smartcar 784N Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charging Status',
+      'friendly_name': 'Smartcar 784N EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_status',
+    'entity_id': 'sensor.smartcar_784n_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'FULLY_CHARGED',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_time_remaining]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'Smartcar 784N Charging Time Remaining',
+      'friendly_name': 'Smartcar 784N EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_time_remaining',
+    'entity_id': 'sensor.smartcar_784n_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_charging_voltage]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'Smartcar 784N Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'Smartcar 784N Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_voltage',
+    'entity_id': 'sensor.smartcar_784n_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_energy_added]
+# name: test_standard_setup_with_all_entities[unknown_make-v2][switch.smartcar_784n_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'Smartcar 784N Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'Smartcar 784N Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_energy_added',
+    'entity_id': 'switch.smartcar_784n_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_engine_oil_life]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_engine_oil_life',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0.35',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_firmware_version]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Firmware Version',
-      'icon': 'mdi:chip',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_firmware_version',
+    'entity_id': 'binary_sensor.smartcar_784n_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_fuel]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_fuel',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '53.2',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_fuel_percent]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_fuel_percent',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '30',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'Smartcar 784N Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_fuel_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '40.5',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_gear_state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Gear State',
-      'icon': 'mdi:car-brake-parking',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_gear_state',
+    'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_last_webhook_received]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Smartcar 784N Last Webhook Received',
-      'icon': 'mdi:clock',
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'Smartcar 784N Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_low_voltage_battery',
+    'entity_id': 'binary_sensor.smartcar_784n_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_odometer]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2019-10-24T00:43:46+00:00',
-      'device_class': 'distance',
-      'friendly_name': 'Smartcar 784N Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+      'device_class': 'running',
+      'friendly_name': 'Smartcar 784N Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '37829',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'Smartcar 784N Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '40.5',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'Smartcar 784N Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_time_to_complete',
+    'entity_id': 'binary_sensor.smartcar_784n_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2019-10-24T00:43:46+00:00',
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '219.3',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2019-10-24T00:43:46+00:00',
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '219.3',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2019-10-24T00:43:46+00:00',
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '219.3',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][sensor.smartcar_784n_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2019-10-24T00:43:46+00:00',
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '219.3',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v2][switch.smartcar_784n_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.smartcar_784n_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_asleep',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_battery_heater_active]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Battery Heater Active',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_battery_heater_active',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_charging_cable_plugged_in]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'Smartcar 784N Charging Cable Plugged In',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_digital_key_paired',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Back Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Back Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'Smartcar 784N Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'Smartcar 784N Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'Smartcar 784N Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'Smartcar 784N Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.smartcar_784n_window_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][device]
@@ -4329,24 +4976,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][device_tracker.smartcar_784n_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Location',
-      'gps_accuracy': 0,
-      'icon': 'mdi:car',
-      'latitude': 37.4292,
-      'longitude': 122.1381,
-      'source_type': <SourceType.GPS: 'gps'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.smartcar_784n_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[unknown_make-v3][entities]
@@ -6228,806 +6857,675 @@
       'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.smartcar_784n_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.smartcar_784n_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.smartcar_784n_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.smartcar_784n_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][lock.smartcar_784n_door_lock]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'Smartcar 784N ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.smartcar_784n_door_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unlocked',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][number.smartcar_784n_charge_limit]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.smartcar_784n_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '80',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'Smartcar 784N Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '30',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_battery_capacity]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'Smartcar 784N Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_battery_capacity',
+    'entity_id': 'sensor.smartcar_784n_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charge_rate]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'Smartcar 784N Charge Rate',
-      'icon': 'mdi:speedometer',
+      'device_class': 'temperature',
+      'friendly_name': 'Smartcar 784N Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charge_rate',
+    'entity_id': 'sensor.smartcar_784n_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_current]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'Smartcar 784N Charging Current',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      'friendly_name': 'Smartcar 784N EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_current',
+    'entity_id': 'sensor.smartcar_784n_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_current_max]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'Smartcar 784N Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_current_max',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_power]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Smartcar 784N Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charging Status',
+      'friendly_name': 'Smartcar 784N EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_status',
+    'entity_id': 'sensor.smartcar_784n_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'FULLY_CHARGED',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_time_remaining]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'Smartcar 784N Charging Time Remaining',
+      'friendly_name': 'Smartcar 784N EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smartcar_784n_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Smartcar 784N Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_time_remaining',
+    'entity_id': 'sensor.smartcar_784n_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_voltage]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'Smartcar 784N Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'Smartcar 784N Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_charging_voltage',
+    'entity_id': 'sensor.smartcar_784n_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_energy_added]
+# name: test_standard_setup_with_all_entities[unknown_make-v3][switch.smartcar_784n_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'Smartcar 784N Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'Smartcar 784N Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_energy_added',
+    'entity_id': 'switch.smartcar_784n_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_engine_oil_life]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2025-09-18T23:30:33+00:00',
-      'fetched_at': '2025-09-18T23:39:43.086000+00:00',
-      'friendly_name': 'Smartcar 784N Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_engine_oil_life',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0.0035',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_firmware_version]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Firmware Version',
-      'icon': 'mdi:chip',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_firmware_version',
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_fuel]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_fuel',
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_fuel_percent]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2025-09-18T23:30:33+00:00',
-      'fetched_at': '2025-09-18T23:39:43.086000+00:00',
-      'friendly_name': 'Smartcar 784N Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_fuel_percent',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '30',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'Smartcar 784N Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_fuel_range',
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_gear_state]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Gear State',
-      'icon': 'mdi:car-brake-parking',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_gear_state',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_last_webhook_received]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'Smartcar 784N Last Webhook Received',
-      'icon': 'mdi:clock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'Smartcar 784N Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_low_voltage_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_odometer]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'Smartcar 784N Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '37829',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'Smartcar 784N Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'Smartcar 784N Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_time_to_complete',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'Smartcar 784N Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.smartcar_784n_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[unknown_make-v3][switch.smartcar_784n_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'Smartcar 784N Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.smartcar_784n_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_asleep',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_battery_heater_active]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Battery Heater Active',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_charging_cable_plugged_in]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'device_class': 'plug',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_back_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][binary_sensor.vw_id_4_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -7063,26 +7561,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][device_tracker.vw_id_4_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:52+00:00',
-      'fetched_at': '2025-05-09T17:27:25.401000+00:00',
-      'friendly_name': 'VW ID.4 Location',
-      'gps_accuracy': 0,
-      'icon': 'mdi:car',
-      'latitude': 37.4292,
-      'longitude': 122.1381,
-      'source_type': <SourceType.GPS: 'gps'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.vw_id_4_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v2][entities]
@@ -8964,818 +9442,679 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.vw_id_4_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][lock.vw_id_4_door_lock]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.vw_id_4_door_lock',
+    'entity_id': 'sensor.vw_id_4_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][number.vw_id_4_charge_limit]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:55+00:00',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.vw_id_4_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '100',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'device_class': 'battery',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Battery',
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '68',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_battery_capacity]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T17:27:25.114000+00:00',
-      'device_class': 'energy_storage',
-      'fetched_at': '2025-05-09T17:27:25.114000+00:00',
-      'friendly_name': 'VW ID.4 Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery_capacity',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '82',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charge_rate]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'VW ID.4 Charge Rate',
-      'icon': 'mdi:speedometer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_current]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current',
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_current_max]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current_max',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_power]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'VW ID.4 Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Charging Status',
+      'friendly_name': 'VW ID.4 EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_status',
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'NOT_CHARGING',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_time_remaining]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_charging_voltage]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'VW ID.4 Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_energy_added]
+# name: test_standard_setup_with_all_entities[vw_id_4-v2][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_energy_added',
+    'entity_id': 'switch.vw_id_4_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_engine_oil_life]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_engine_oil_life',
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_firmware_version]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Firmware Version',
-      'icon': 'mdi:chip',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_fuel]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel',
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_fuel_percent]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_percent',
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_gear_state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Gear State',
-      'icon': 'mdi:car-brake-parking',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_gear_state',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_last_webhook_received]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'VW ID.4 Last Webhook Received',
-      'icon': 'mdi:clock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_odometer]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:52+00:00',
-      'device_class': 'distance',
-      'fetched_at': '2025-05-09T17:27:25.401000+00:00',
-      'friendly_name': 'VW ID.4 Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '21919',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'device_class': 'distance',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '275',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_time_to_complete',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][sensor.vw_id_4_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v2][switch.vw_id_4_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'age': '2025-05-09T15:40:57+00:00',
-      'fetched_at': '2025-05-09T17:27:26.712000+00:00',
-      'friendly_name': 'VW ID.4 Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.vw_id_4_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_asleep',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_battery_heater_active]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Battery Heater Active',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_charging_cable_plugged_in]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'on',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
   })
 # ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][device]
@@ -9807,24 +10146,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][device_tracker.vw_id_4_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Location',
-      'gps_accuracy': 0,
-      'icon': 'mdi:car',
-      'latitude': 37.4292,
-      'longitude': 122.1381,
-      'source_type': <SourceType.GPS: 'gps'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.vw_id_4_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'not_home',
   })
 # ---
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][entities]
@@ -11706,800 +12027,675 @@
       'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.vw_id_4_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'a1d50709-3502-4faa-ba43-a5c7565e6a09_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][lock.vw_id_4_door_lock]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.vw_id_4_door_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'locked',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][number.vw_id_4_charge_limit]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.vw_id_4_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '80',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '57',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_battery_capacity]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'entity_id': 'sensor.vw_id_4_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charge_rate]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'VW ID.4 Charge Rate',
-      'icon': 'mdi:speedometer',
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charge_rate',
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_current]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current',
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_current_max]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current_max',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_power]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'VW ID.4 Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging Status',
+      'friendly_name': 'VW ID.4 EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_status',
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'NOT_CHARGING',
+    'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_time_remaining]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_voltage]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'VW ID.4 Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_energy_added]
+# name: test_standard_setup_with_all_entities[vw_id_4-v3][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_energy_added',
+    'entity_id': 'switch.vw_id_4_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_engine_oil_life]
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_engine_oil_life',
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_firmware_version]
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Firmware Version',
-      'icon': 'mdi:chip',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_fuel]
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel',
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_fuel_percent]
+# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_percent',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_gear_state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Gear State',
-      'icon': 'mdi:car-brake-parking',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_gear_state',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_last_webhook_received]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'VW ID.4 Last Webhook Received',
-      'icon': 'mdi:clock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_odometer]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '52891',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '253',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_time_to_complete',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_standard_setup_with_all_entities[vw_id_4-v3][switch.vw_id_4_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.vw_id_4_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_asleep',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Battery Heater Active',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][binary_sensor.vw_id_4_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12535,20 +12731,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][device_tracker.vw_id_4_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Location',
-      'icon': 'mdi:car',
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.vw_id_4_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[network_error-vw_id_4][entities]
@@ -14430,800 +14612,675 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.vw_id_4_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_update_errors[network_error-vw_id_4][lock.vw_id_4_door_lock]
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.vw_id_4_door_lock',
+    'entity_id': 'sensor.vw_id_4_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][number.vw_id_4_charge_limit]
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.vw_id_4_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Battery',
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery',
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_battery_capacity]
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charge_rate]
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'VW ID.4 Charge Rate',
-      'icon': 'mdi:speedometer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charge_rate',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_current]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_current_max]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current_max',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_power]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'VW ID.4 Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging Status',
+      'friendly_name': 'VW ID.4 EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_status',
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_charging_voltage]
+# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'VW ID.4 Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_energy_added]
+# name: test_update_errors[network_error-vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_energy_added',
+    'entity_id': 'switch.vw_id_4_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_engine_oil_life]
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_engine_oil_life',
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_firmware_version]
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Firmware Version',
-      'icon': 'mdi:chip',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_fuel]
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel',
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_fuel_percent]
+# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_percent',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_gear_state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Gear State',
-      'icon': 'mdi:car-brake-parking',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_gear_state',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_last_webhook_received]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'VW ID.4 Last Webhook Received',
-      'icon': 'mdi:clock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_odometer]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_time_to_complete',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_error-vw_id_4][switch.vw_id_4_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.vw_id_4_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_asleep',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Battery Heater Active',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][binary_sensor.vw_id_4_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -15259,20 +15316,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][device_tracker.vw_id_4_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Location',
-      'icon': 'mdi:car',
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.vw_id_4_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[network_proxy_response-vw_id_4][entities]
@@ -17154,800 +17197,675 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.vw_id_4_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][lock.vw_id_4_door_lock]
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.vw_id_4_door_lock',
+    'entity_id': 'sensor.vw_id_4_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][number.vw_id_4_charge_limit]
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.vw_id_4_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Battery',
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery',
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_battery_capacity]
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charge_rate]
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'VW ID.4 Charge Rate',
-      'icon': 'mdi:speedometer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charge_rate',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_current]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_current_max]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current_max',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_power]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'VW ID.4 Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging Status',
+      'friendly_name': 'VW ID.4 EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_status',
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_charging_voltage]
+# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'VW ID.4 Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_energy_added]
+# name: test_update_errors[network_proxy_response-vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_energy_added',
+    'entity_id': 'switch.vw_id_4_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_engine_oil_life]
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_engine_oil_life',
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_firmware_version]
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Firmware Version',
-      'icon': 'mdi:chip',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_fuel]
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel',
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_fuel_percent]
+# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_percent',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_gear_state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Gear State',
-      'icon': 'mdi:car-brake-parking',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_gear_state',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_last_webhook_received]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'VW ID.4 Last Webhook Received',
-      'icon': 'mdi:clock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_odometer]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_time_to_complete',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[network_proxy_response-vw_id_4][switch.vw_id_4_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.vw_id_4_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_asleep',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Battery Heater Active',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][binary_sensor.vw_id_4_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -17983,20 +17901,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][device_tracker.vw_id_4_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Location',
-      'icon': 'mdi:car',
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.vw_id_4_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[server_error-vw_id_4][entities]
@@ -19878,800 +19782,675 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.vw_id_4_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_update_errors[server_error-vw_id_4][lock.vw_id_4_door_lock]
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.vw_id_4_door_lock',
+    'entity_id': 'sensor.vw_id_4_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][number.vw_id_4_charge_limit]
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.vw_id_4_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Battery',
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery',
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_battery_capacity]
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charge_rate]
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'VW ID.4 Charge Rate',
-      'icon': 'mdi:speedometer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charge_rate',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_current]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_current_max]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current_max',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_power]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'VW ID.4 Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging Status',
+      'friendly_name': 'VW ID.4 EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_status',
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_charging_voltage]
+# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'VW ID.4 Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_energy_added]
+# name: test_update_errors[server_error-vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_energy_added',
+    'entity_id': 'switch.vw_id_4_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_engine_oil_life]
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_cabin_hvac_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Cabin HVAC Active',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_engine_oil_life',
+    'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_firmware_version]
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_front_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Firmware Version',
-      'icon': 'mdi:chip',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Front Defroster Active',
+      'icon': 'mdi:car-defrost-front',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_firmware_version',
+    'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_fuel]
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_rear_defroster_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Rear Defroster Active',
+      'icon': 'mdi:car-defrost-rear',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel',
+    'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_fuel_percent]
+# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_steering_wheel_heater_active]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'device_class': 'running',
+      'friendly_name': 'VW ID.4 Steering Wheel Heater Active',
+      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_percent',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_gear_state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Gear State',
-      'icon': 'mdi:car-brake-parking',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_gear_state',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_last_webhook_received]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'VW ID.4 Last Webhook Received',
-      'icon': 'mdi:clock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_odometer]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_time_to_complete',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[server_error-vw_id_4][switch.vw_id_4_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.vw_id_4_charging',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_asleep]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Asleep',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_asleep',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_battery_heater_active]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Battery Heater Active',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_battery_heater_active',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_charging_cable_plugged_in]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Charging Cable Plugged In',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_charging_cable_plugged_in',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_digital_key_paired]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Digital Key Paired',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_digital_key_paired',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Back Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_back_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Back Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_back_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Left',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_left_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Left Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_left_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Door Front Right',
-      'icon': 'mdi:car-door',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_door_front_right_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Door Front Right Lock',
-      'icon': 'mdi:car-door-lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_door_front_right_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_engine_cover]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Engine Cover',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_engine_cover',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_fast_charger_connected]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'plug',
-      'friendly_name': 'VW ID.4 Fast Charger Connected',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_fast_charger_connected',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_front_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Front Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_front_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Front Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_front_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_online]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Online',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_online',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_rear_trunk]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Rear Trunk',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_rear_trunk_lock]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'lock',
-      'friendly_name': 'VW ID.4 Rear Trunk Lock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_rear_trunk_lock',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_sunroof]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'door',
-      'friendly_name': 'VW ID.4 Sunroof',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_sunroof',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_surveillance_enabled]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Surveillance Enabled',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_surveillance_enabled',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Back Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Left',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][binary_sensor.vw_id_4_window_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'window',
-      'friendly_name': 'VW ID.4 Window Front Right',
-    }),
-    'context': <ANY>,
-    'entity_id': 'binary_sensor.vw_id_4_window_front_right',
+    'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -20707,20 +20486,6 @@
     'serial_number': None,
     'sw_version': None,
     'via_device_id': None,
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][device_tracker.vw_id_4_location]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Location',
-      'icon': 'mdi:car',
-    }),
-    'context': <ANY>,
-    'entity_id': 'device_tracker.vw_id_4_location',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
   })
 # ---
 # name: test_update_errors[unauthorized-vw_id_4][entities]
@@ -22602,447 +22367,615 @@
       'unique_id': 'VIWP1AB29P15LA85784N_last_webhook_received',
       'unit_of_measurement': None,
     }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_abs_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-brake-abs',
+      'original_name': 'ABS Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_abs',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:engine',
+      'original_name': 'Malfunction Indicator Lamp',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_mil',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_code_count',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:alert-circle',
+      'original_name': 'Trouble Code Count',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_count',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_trouble_codes',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:format-list-bulleted',
+      'original_name': 'Trouble Codes',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_dtc_list',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:battery-heart-variant',
+      'original_name': 'EV Battery Conditioning Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_battery_conditioning',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_charging_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:ev-station',
+      'original_name': 'EV Charging Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_charging',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:cog',
+      'original_name': 'EV Drive Unit Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_drive_unit',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+      'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:car-battery',
+      'original_name': 'EV High Voltage Battery Status',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_diag_ev_hv_battery',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 1,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+      'original_icon': 'mdi:thermostat',
+      'original_name': 'Cabin Target Temperature',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_cabin_target_temperature',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_cabin_hvac_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Cabin HVAC Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_cabin_hvac_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_front_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-front',
+      'original_name': 'Front Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_front_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_rear_defroster_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:car-defrost-rear',
+      'original_name': 'Rear Defroster Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_rear_defroster_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.vw_id_4_steering_wheel_heater_active',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+      'original_icon': 'mdi:steering',
+      'original_name': 'Steering Wheel Heater Active',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_is_steering_heater_active',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'switch',
+      'entity_category': None,
+      'entity_id': 'switch.vw_id_4_climate',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:air-conditioner',
+      'original_name': 'Climate',
+      'platform': 'smartcar',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': 0,
+      'translation_key': None,
+      'unique_id': 'VIWP1AB29P15LA85784N_climate',
+      'unit_of_measurement': None,
+    }),
   ])
 # ---
-# name: test_update_errors[unauthorized-vw_id_4][lock.vw_id_4_door_lock]
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_abs_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Door Lock',
-      'supported_features': <LockEntityFeature: 0>,
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
     }),
     'context': <ANY>,
-    'entity_id': 'lock.vw_id_4_door_lock',
+    'entity_id': 'sensor.vw_id_4_abs_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[unauthorized-vw_id_4][number.vw_id_4_charge_limit]
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_cabin_target_temperature]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charge Limit',
-      'icon': 'mdi:battery-charging-80',
-      'max': 100.0,
-      'min': 50.0,
-      'mode': <NumberMode.BOX: 'box'>,
-      'step': 1.0,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'number.vw_id_4_charge_limit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Battery',
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery',
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_battery_capacity]
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_ev_battery_conditioning_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Battery Capacity',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charge_rate]
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_ev_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'speed',
-      'friendly_name': 'VW ID.4 Charge Rate',
-      'icon': 'mdi:speedometer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charge_rate',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_current]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_current_max]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'current',
-      'friendly_name': 'VW ID.4 Charging Current Max',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_current_max',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_power]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'VW ID.4 Charging Power',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_power',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_status]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging Status',
+      'friendly_name': 'VW ID.4 EV Charging Status',
       'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_status',
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_time_remaining]
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_ev_drive_unit_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Charging Time Remaining',
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_time_remaining',
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_charging_voltage]
+# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_trouble_codes]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'voltage',
-      'friendly_name': 'VW ID.4 Charging Voltage',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_charging_voltage',
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
   })
 # ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_energy_added]
+# name: test_update_errors[unauthorized-vw_id_4][switch.vw_id_4_climate]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy_storage',
-      'friendly_name': 'VW ID.4 Energy Added',
-      'icon': 'mdi:lightning-bolt',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_energy_added',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_engine_oil_life]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Engine Oil Life',
-      'icon': 'mdi:oil-level',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_engine_oil_life',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_firmware_version]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Firmware Version',
-      'icon': 'mdi:chip',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_firmware_version',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_fuel]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfVolume.LITERS: 'L'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_fuel_percent]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Fuel Percent',
-      'icon': 'mdi:gas-station',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_percent',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_fuel_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Fuel Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_fuel_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_gear_state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Gear State',
-      'icon': 'mdi:car-brake-parking',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_gear_state',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_last_webhook_received]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'timestamp',
-      'friendly_name': 'VW ID.4 Last Webhook Received',
-      'icon': 'mdi:clock',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_last_webhook_received',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_low_voltage_battery]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'battery',
-      'friendly_name': 'VW ID.4 Low Voltage Battery',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': '%',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_low_voltage_battery',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_odometer]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Odometer',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_odometer',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_range]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'distance',
-      'friendly_name': 'VW ID.4 Range',
-      'icon': 'mdi:map-marker-distance',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_range',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_time_to_complete]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'duration',
-      'friendly_name': 'VW ID.4 Time to Complete',
-      'icon': 'mdi:timer',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_time_to_complete',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_back_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_back_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Back Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_back_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_front_left]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Left',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_left',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][sensor.vw_id_4_tire_pressure_front_right]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'pressure',
-      'friendly_name': 'VW ID.4 Tire Pressure Front Right',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPressure.KPA: 'kPa'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_update_errors[unauthorized-vw_id_4][switch.vw_id_4_charging]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'friendly_name': 'VW ID.4 Charging',
-      'icon': 'mdi:ev-plug-type2',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.vw_id_4_charging',
+    'entity_id': 'switch.vw_id_4_climate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/snapshots/test_sensor.ambr
+++ b/tests/snapshots/test_sensor.ambr
@@ -452,6 +452,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -478,6 +492,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -628,6 +659,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -731,6 +818,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -851,6 +952,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[broad_auth_error-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -877,6 +1021,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1027,6 +1188,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1131,6 +1348,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1251,6 +1482,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_json-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1277,6 +1551,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1427,6 +1718,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1531,6 +1878,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1651,6 +2012,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[invalid_signature-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1677,6 +2081,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -1827,6 +2248,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -1930,6 +2407,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2050,6 +2541,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[irrelevant_auth_error-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2076,6 +2610,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2226,6 +2777,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2330,6 +2937,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2450,6 +3071,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[test_mode-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2476,6 +3140,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2626,6 +3307,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2729,6 +3466,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -2849,6 +3600,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_error-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -2875,6 +3669,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3025,6 +3836,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -3129,6 +3996,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3249,6 +4130,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_mismatch-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -3277,6 +4201,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3427,6 +4368,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -3530,6 +4527,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3652,6 +4663,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -3678,6 +4732,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -3828,6 +4899,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -3935,6 +5062,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4055,6 +5196,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[vehicle_state_fuel-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4081,6 +5265,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4231,6 +5432,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4335,6 +5592,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4455,6 +5726,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_scenarios[verify-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4483,6 +5797,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.byd_seal_u_dm_i_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'BYD Seal U Dm-i Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4633,6 +5964,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4736,6 +6123,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.byd_seal_u_dm_i_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -4858,6 +6259,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-sensor][sensor.byd_seal_u_dm_i_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.byd_seal_u_dm_i_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -4892,6 +6336,23 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '90',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'JAGUAR I-PACE Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_charge_rate]
@@ -5040,6 +6501,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -5149,6 +6666,20 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '100',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_odometer]
@@ -5269,6 +6800,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-sensor][sensor.jaguar_i_pace_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -5303,6 +6877,23 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '90',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'JAGUAR I-PACE Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_charge_rate]
@@ -5457,6 +7048,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -5568,6 +7215,20 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '82',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_malfunction_indicator_lamp',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_odometer]
@@ -5698,6 +7359,49 @@
     'state': '699.9',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace2-sensor][sensor.jaguar_i_pace_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.jaguar_i_pace_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'none',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -5730,6 +7434,23 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '82',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'POLESTAR Polestar 2 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_cabin_target_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_charge_rate]
@@ -5888,6 +7609,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -5993,6 +7770,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.polestar_polestar_2_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -6119,6 +7910,49 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-polestar_2-sensor][sensor.polestar_polestar_2_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'POLESTAR Polestar 2 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.polestar_polestar_2_trouble_codes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_abs_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 ABS Status',
+      'icon': 'mdi:car-brake-abs',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_abs_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -6147,6 +7981,23 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_battery_capacity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_cabin_target_temperature]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'temperature',
+      'friendly_name': 'VW ID.4 Cabin Target Temperature',
+      'icon': 'mdi:thermostat',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_cabin_target_temperature',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -6297,6 +8148,62 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_ev_battery_conditioning_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Battery Conditioning Status',
+      'icon': 'mdi:battery-heart-variant',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_battery_conditioning_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_ev_charging_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Charging Status',
+      'icon': 'mdi:ev-station',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_charging_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_ev_drive_unit_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV Drive Unit Status',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_drive_unit_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_ev_high_voltage_battery_status]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 EV High Voltage Battery Status',
+      'icon': 'mdi:car-battery',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_ev_high_voltage_battery_status',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_firmware_version]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -6400,6 +8307,20 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_low_voltage_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_malfunction_indicator_lamp]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Malfunction Indicator Lamp',
+      'icon': 'mdi:engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_malfunction_indicator_lamp',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -6516,6 +8437,35 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.vw_id_4_tire_pressure_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_trouble_code_count]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Code Count',
+      'icon': 'mdi:alert-circle',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_code_count',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-sensor][sensor.vw_id_4_trouble_codes]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Trouble Codes',
+      'icon': 'mdi:format-list-bulleted',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.vw_id_4_trouble_codes',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/snapshots/test_switch.ambr
+++ b/tests/snapshots/test_switch.ambr
@@ -275,6 +275,20 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-byd_seal-switch][switch.byd_seal_u_dm_i_climate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'BYD Seal U Dm-i Climate',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.byd_seal_u_dm_i_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-jaguar_ipace-switch][switch.jaguar_i_pace_charging]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -291,6 +305,20 @@
     'state': 'on',
   })
 # ---
+# name: test_webhook_update[vehicle_state_all-jaguar_ipace-switch][switch.jaguar_i_pace_climate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'JAGUAR I-PACE Climate',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.jaguar_i_pace_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
 # name: test_webhook_update[vehicle_state_all-vw_id_4-switch][switch.vw_id_4_charging]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -303,5 +331,19 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'off',
+  })
+# ---
+# name: test_webhook_update[vehicle_state_all-vw_id_4-switch][switch.vw_id_4_climate]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'VW ID.4 Climate',
+      'icon': 'mdi:air-conditioner',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vw_id_4_climate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -5,6 +5,17 @@ from collections.abc import Awaitable, Callable
 from homeassistant.const import Platform
 import pytest
 
+from custom_components.smartcar import binary_sensor as binary_sensor_module
+
+
+def test_hvac_bool_cast() -> None:
+    """Test extraction of HVAC booleans from webhook signal bodies."""
+    assert binary_sensor_module._hvac_bool({"value": True}) is True
+    assert binary_sensor_module._hvac_bool({"value": False}) is False
+    assert binary_sensor_module._hvac_bool({}) is None
+    assert binary_sensor_module._hvac_bool(False) is False  # noqa: FBT003
+    assert binary_sensor_module._hvac_bool(None) is None
+
 
 @pytest.mark.usefixtures("enable_all_entities")
 @pytest.mark.parametrize("platform", [Platform.BINARY_SENSOR])

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -984,6 +984,203 @@ async def test_reauth(
     assert compare_entry_data == expected_entry_data
 
 
+@pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.parametrize("vehicle_fixture", ["vw_id_4"])
+@pytest.mark.parametrize(
+    (
+        "entry_data",
+        "user_input",
+        "new_vehicle_id",
+        "expected_result",
+    ),
+    [
+        (
+            {},
+            {"use_webhooks": False},
+            "a1d50709-3502-4faa-ba43-a5c7565e6a09",
+            {
+                "abort_reason": "reconfigure_successful",
+                "access_token": "updated-access-token",
+                "setup_calls": 1,
+            },
+        ),
+        (
+            {
+                CONF_APPLICATION_MANAGEMENT_TOKEN: "old_mock_amt",
+                CONF_CLOUDHOOK: False,
+                CONF_WEBHOOK_ID: "original_webhook_id",
+            },
+            {"use_webhooks": True, CONF_APPLICATION_MANAGEMENT_TOKEN: "mock_amt"},
+            "a1d50709-3502-4faa-ba43-a5c7565e6a09",
+            {
+                "abort_reason": "reconfigure_successful",
+                "access_token": "updated-access-token",
+                "setup_calls": 1,
+                "entry_data": {
+                    CONF_APPLICATION_MANAGEMENT_TOKEN: "mock_amt",
+                    CONF_CLOUDHOOK: False,
+                    CONF_WEBHOOK_ID: "original_webhook_id",
+                },
+            },
+        ),
+        (
+            {
+                CONF_APPLICATION_MANAGEMENT_TOKEN: "old_mock_amt",
+                CONF_CLOUDHOOK: False,
+                CONF_WEBHOOK_ID: "original_webhook_id",
+            },
+            {"use_webhooks": False},
+            "a1d50709-3502-4faa-ba43-a5c7565e6a09",
+            {
+                "abort_reason": "reconfigure_successful",
+                "access_token": "updated-access-token",
+                "setup_calls": 1,
+            },
+        ),
+        (
+            {},
+            {"use_webhooks": False},
+            "a-different-vehicle-id",
+            {
+                "abort_reason": "wrong_vehicles",
+                "placeholders": {"vins": "VIWP1AB29P15LA85784N"},
+                "access_token": "mock-access-token",
+                "setup_calls": 0,
+            },
+        ),
+    ],
+    ids=[
+        "reconfigure_successful",
+        "reconfigure_keeps_webhook_id",
+        "reconfigure_disables_webhooks",
+        "wrong_vehicles",
+    ],
+)
+async def test_reconfigure(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    vehicle_fixture: str,
+    vehicle_attributes: dict,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_smartcar_auth: AsyncMock,
+    entry_data: dict,
+    user_input: dict,
+    new_vehicle_id: str,
+    expected_result: dict[str, Any],
+) -> None:
+    """Test the reconfiguration flow."""
+    expected_abort_reason = expected_result.get("abort_reason")
+    expected_placeholders = expected_result.get("placeholders")
+    expected_access_token = expected_result.get("access_token")
+    expected_setup_calls = expected_result.get("setup_calls", 1)
+    expected_entry_data = expected_result.get("entry_data", {})
+
+    mock_config_entry.add_to_hass(hass)
+
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        data={**mock_config_entry.data, **entry_data},
+    )
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "webhooks"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "scopes"
+
+    selected_scopes = ["read_odometer"]
+    requested_scopes = REQUIRED_SCOPES + selected_scopes
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {k: k in selected_scopes for k in CONFIGURABLE_SCOPES},
+    )
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": REDIRECT_URL,
+        },
+    )
+
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+    assert result["step_id"] == "auth"
+
+    client = await hass_client_no_auth()
+    resp = await client.get(f"/auth/external/callback?code=abcd&state={state}")
+    assert resp.status == 200
+    assert resp.headers["content-type"] == "text/html; charset=utf-8"
+
+    vin = "5YJSA1CN5DFP00101"
+    server_access_token = {
+        "refresh_token": "mock-refresh-token",
+        "access_token": "updated-access-token",
+        "type": "Bearer",
+        "expires_in": 60,
+        "scope": " ".join(requested_scopes),
+    }
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN_LEGACY,
+        json=server_access_token,
+    )
+    aioclient_mock.get(
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles",
+        json={"paging": {"count": 25, "offset": 0}, "vehicles": [new_vehicle_id]},
+    )
+    aioclient_mock.get(
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{new_vehicle_id}/vin", json={"vin": vin}
+    )
+    aioclient_mock.get(
+        f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{new_vehicle_id}",
+        json={
+            "id": new_vehicle_id,
+            "make": "TESLA",
+            "model": "Model S",
+            "year": "2014",
+        },
+    )
+
+    with (
+        patch(
+            "custom_components.smartcar.async_setup_entry", return_value=True
+        ) as mock_setup,
+        patch(
+            "homeassistant.components.cloud.async_active_subscription",
+            return_value=False,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+        await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert len(mock_setup.mock_calls) == expected_setup_calls
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == expected_abort_reason
+    assert result["description_placeholders"] == expected_placeholders
+
+    assert mock_config_entry.unique_id == vehicle_attributes["id"]
+    assert "token" in mock_config_entry.data
+
+    # limit scope of comparison for config entry data
+    compare_entry_data = {**mock_config_entry.data}
+    token = compare_entry_data.pop("token")
+    compare_entry_data.pop("auth_implementation", None)
+    compare_entry_data.pop("vehicles", None)
+
+    # verify access token is refreshed
+    assert token["access_token"] == expected_access_token
+    assert token["refresh_token"] == "mock-refresh-token"  # noqa: S105
+    assert compare_entry_data == expected_entry_data
+
+
 @pytest.mark.parametrize("vehicle_fixture", ["vw_id_4"])
 @pytest.mark.parametrize(
     ("setup", "entry_data", "user_input", "expected_result"),

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -577,6 +577,21 @@ _SNAPSHOT_ORDER = {
             "charge_fast_charger_present",
             "firmware_version",
             "last_webhook_received",
+            "is_cabin_hvac_active",
+            "diag_abs",
+            "diag_mil",
+            "diag_dtc_count",
+            "diag_dtc_list",
+            "diag_ev_battery_conditioning",
+            "diag_ev_charging",
+            "diag_ev_drive_unit",
+            "diag_ev_hv_battery",
+            "cabin_target_temperature",
+            "is_cabin_hvac_active",
+            "is_front_defroster_active",
+            "is_rear_defroster_active",
+            "is_steering_heater_active",
+            "climate",
         ]
     )
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,6 @@
 """Test component setup."""
 
+import logging
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.components import cloud
@@ -14,6 +15,7 @@ from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClien
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props
 
+from custom_components.smartcar import coordinator as coordinator_module
 from custom_components.smartcar.const import (
     CONF_APPLICATION_MANAGEMENT_TOKEN,
     CONF_CLOUDHOOK,
@@ -601,3 +603,29 @@ def snapshot_order(entity):
     _, key = entity.unique_id.split("_", 1)
 
     return _SNAPSHOT_ORDER[key]
+
+
+@pytest.mark.parametrize(
+    ("error_type", "error_code", "expected_level"),
+    [
+        ("VEHICLE_STATE", "NOT_CHARGING", logging.DEBUG),
+        ("COMPATIBILITY", "VEHICLE_NOT_CAPABLE", logging.DEBUG),
+        ("PERMISSION", None, logging.ERROR),
+    ],
+    ids=["not_charging", "not_capable", "genuine_error"],
+)
+def test_webhook_signal_error_log_level(
+    caplog: pytest.LogCaptureFixture,
+    error_type: str,
+    error_code: str | None,
+    expected_level: int,
+) -> None:
+    """Test benign signal errors are demoted to DEBUG while others are not."""
+    with caplog.at_level(logging.DEBUG, logger="custom_components.smartcar"):
+        coordinator_module._handle_webhook_signal_error(
+            "Wattage",
+            {"type": error_type, "code": error_code},
+        )
+
+    record = next(r for r in caplog.records if "error for signal" in r.message)
+    assert record.levelno == expected_level

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -23,6 +23,7 @@ from pytest_homeassistant_custom_component.common import (
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 from syrupy.assertion import SnapshotAssertion
 
+from custom_components.smartcar import sensor as sensor_module
 from custom_components.smartcar.const import (
     DEFAULT_ENABLED_ENTITY_DESCRIPTION_KEYS,
     OAUTH2_TOKEN_LEGACY,
@@ -40,6 +41,45 @@ from custom_components.smartcar.sensor import SmartcarSensorDescription
 from custom_components.smartcar.types import APIVersion
 
 from . import setup_added_integration, setup_integration
+
+
+def test_diag_status_cast() -> None:
+    """Test extraction of diagnostic statuses from webhook signal bodies."""
+    assert sensor_module._diag_status({"status": "OK"}) == "OK"
+    assert sensor_module._diag_status({"value": "WARNING"}) == "WARNING"
+    assert sensor_module._diag_status({}) is None
+    assert sensor_module._diag_status("OK") == "OK"
+    assert sensor_module._diag_status(None) is None
+
+
+def test_dtc_count_cast() -> None:
+    """Test extraction of trouble code counts from webhook signal bodies."""
+    assert sensor_module._dtc_count({"value": 2}) == 2
+    assert sensor_module._dtc_count({"count": 3}) == 3
+    assert sensor_module._dtc_count({}) is None
+    assert sensor_module._dtc_count(4) == 4
+    assert sensor_module._dtc_count(None) is None
+
+
+def test_dtc_list_cast() -> None:
+    """Test extraction of trouble code lists from webhook signal bodies."""
+    assert (
+        sensor_module._dtc_list({"value": [{"code": "P0100"}, "P0200"]})
+        == "P0100, P0200"
+    )
+    assert sensor_module._dtc_list({"values": ["P0300"]}) == "P0300"
+    assert sensor_module._dtc_list({"codes": ["P0400"]}) == "P0400"
+    assert sensor_module._dtc_list({"value": "P0500"}) == "P0500"
+    assert sensor_module._dtc_list({}) == "none"
+    assert sensor_module._dtc_list(None) is None
+
+
+def test_hvac_number_cast() -> None:
+    """Test extraction of HVAC numbers from webhook signal bodies."""
+    assert sensor_module._hvac_number({"value": 21.5}) == 21.5
+    assert sensor_module._hvac_number({}) is None
+    assert sensor_module._hvac_number(19) == 19
+    assert sensor_module._hvac_number(None) is None
 
 
 @pytest.mark.usefixtures("enable_all_entities")

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
+    STATE_UNKNOWN,
     Platform,
 )
 from homeassistant.core import HomeAssistant, State
@@ -22,6 +23,7 @@ from pytest_homeassistant_custom_component.common import (
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 from syrupy.assertion import SnapshotAssertion
 
+from custom_components.smartcar import switch as switch_module
 from custom_components.smartcar.types import APIVersion
 
 from . import (
@@ -137,6 +139,105 @@ async def test_switch(
 )
 async def test_webhook_update(webhook_scenario: Callable[[], Awaitable[None]]) -> None:
     await webhook_scenario()
+
+
+def test_hvac_bool_cast() -> None:
+    """Test extraction of HVAC booleans from webhook signal bodies."""
+    assert switch_module._hvac_bool({"value": True}) is True
+    assert switch_module._hvac_bool({"value": False}) is False
+    assert switch_module._hvac_bool({}) is None
+    assert switch_module._hvac_bool(True) is True  # noqa: FBT003
+    assert switch_module._hvac_bool(None) is None
+
+
+@pytest.mark.parametrize("client_id_version", ["v2", "v3"])
+@pytest.mark.parametrize(
+    (
+        "service_action",
+        "api_status",
+        "api_status_slug",
+        "expected_state",
+        "expected_v2_action",
+    ),
+    [
+        (SERVICE_TURN_ON, 200, "success", STATE_ON, "START"),
+        (SERVICE_TURN_OFF, 200, "success", STATE_OFF, "STOP"),
+        (SERVICE_TURN_ON, 409, "unreachable", STATE_UNKNOWN, "START"),
+        (SERVICE_TURN_OFF, 409, "unreachable", STATE_UNKNOWN, "STOP"),
+    ],
+    ids=["turn_on", "turn_off", "turn_on_unreachable", "turn_off_unreachable"],
+)
+@pytest.mark.parametrize("vehicle_fixture", ["unknown_make"])
+async def test_climate_switch(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    aioclient_mock: AiohttpClientMocker,
+    vehicle: AsyncMock,
+    service_action: str,
+    api_status: int,
+    api_status_slug: str,
+    expected_state: str,
+    expected_v2_action: str,
+    client_id_version: APIVersion,
+) -> None:
+    """Test starting/stopping climate (preconditioning)."""
+
+    await setup_integration(hass, mock_config_entry)
+    assert len(aioclient_mock.mock_calls) == 1
+
+    if client_id_version == "v2":
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT_LEGACY}/vehicles/{vehicle['id']}/climate",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
+    else:
+        assert client_id_version == "v3"
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT}/vehicles/{vehicle['id']}/commands/climate/start",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
+        aioclient_mock.post(
+            f"{MOCK_API_ENDPOINT}/vehicles/{vehicle['id']}/commands/climate/stop",
+            status=api_status,
+            json={
+                "message": "Some message related to the action unused by our code",
+                "status": api_status_slug,
+            },
+        )
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        service_action,
+        {ATTR_ENTITY_ID: "switch.smartcar_784n_climate"},
+        blocking=True,
+    )
+
+    switch_state = hass.states.get("switch.smartcar_784n_climate")
+    assert switch_state.state == expected_state
+
+    assert len(aioclient_mock.mock_calls) == 2
+
+    (method, url, data, _headers) = aioclient_mock.mock_calls[1]
+    expected_subpath = "start" if service_action == SERVICE_TURN_ON else "stop"
+
+    assert method == "POST"
+
+    if client_id_version == "v2":
+        assert str(url).endswith(f"/vehicles/{vehicle['id']}/climate")
+        assert data == {"action": expected_v2_action}
+    else:
+        assert str(url).endswith(
+            f"/vehicles/{vehicle['id']}/commands/climate/{expected_subpath}"
+        )
+        assert data is None
 
 
 RESTORE_STATE_V2_PARAMETRIZE_ARGS = [

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -11,7 +11,6 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
-    STATE_UNKNOWN,
     Platform,
 )
 from homeassistant.core import HomeAssistant, State
@@ -162,8 +161,8 @@ def test_hvac_bool_cast() -> None:
     [
         (SERVICE_TURN_ON, 200, "success", STATE_ON, "START"),
         (SERVICE_TURN_OFF, 200, "success", STATE_OFF, "STOP"),
-        (SERVICE_TURN_ON, 409, "unreachable", STATE_UNKNOWN, "START"),
-        (SERVICE_TURN_OFF, 409, "unreachable", STATE_UNKNOWN, "STOP"),
+        (SERVICE_TURN_ON, 409, "unreachable", STATE_OFF, "START"),
+        (SERVICE_TURN_OFF, 409, "unreachable", STATE_OFF, "STOP"),
     ],
     ids=["turn_on", "turn_off", "turn_on_unreachable", "turn_off_unreachable"],
 )
@@ -184,6 +183,16 @@ async def test_climate_switch(
 
     await setup_integration(hass, mock_config_entry)
     assert len(aioclient_mock.mock_calls) == 1
+
+    # seed HVAC data (not present in the vehicle fixture) so the climate
+    # switch becomes available and starts from a known state
+    coordinator = mock_config_entry.runtime_data.coordinators[vehicle["id"]]
+    coordinator.async_set_updated_data(
+        {**(coordinator.data or {}), "hvac-iscabinhvacactive": {"value": False}}
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get("switch.smartcar_784n_climate").state == STATE_OFF
 
     if client_id_version == "v2":
         aioclient_mock.post(
@@ -228,7 +237,7 @@ async def test_climate_switch(
     (method, url, data, _headers) = aioclient_mock.mock_calls[1]
     expected_subpath = "start" if service_action == SERVICE_TURN_ON else "stop"
 
-    assert method == "POST"
+    assert method == "post"
 
     if client_id_version == "v2":
         assert str(url).endswith(f"/vehicles/{vehicle['id']}/climate")


### PR DESCRIPTION
> [!NOTE]
> Rebased onto `v3-auth` including 025add2 (vehicle-UUID keying) — this PR now carries only its own two commits, with nothing from #125.

This proposes two features that came out of setting up the v3 API end-to-end (#123), plus a small logging cleanup.

## 1. Reconfigure flow (`async_step_reconfigure`)

Today, changing the granted permissions or webhook settings requires deleting and re-adding the integration (losing entity customizations). This adds support for the standard HA **Reconfigure** flow:

- replays the webhooks and scopes steps, then re-runs the OAuth authorization so scopes can be added/removed after setup;
- **reuses the existing webhook ID**, so the callback URI registered in the Smartcar dashboard stays valid;
- drops stale webhook details (management token, webhook ID, cloudhook) when webhooks are disabled during reconfigure;
- aborts with `wrong_vehicles` if the re-auth selects different vehicles, mirroring the reauth behavior.

## 2. Diagnostics & climate entities (new scopes)

Adds three permission scopes and their entities, all webhook-only signals:

| Scope | Entities |
|---|---|
| `read_diagnostics` | 8 diagnostic sensors: ABS status, malfunction indicator lamp, DTC count, DTC list, EV battery conditioning, EV charging, EV drive unit, EV high-voltage battery |
| `read_climate` | Cabin target temperature sensor; binary sensors for cabin HVAC active, front/rear defroster, steering wheel heater |
| `control_climate` | **Climate switch** to start/stop cabin preconditioning (`/climate/start` & `/climate/stop` on v3; `/climate` with an `action` payload on v2) |

Caveat worth flagging: the exact body field names for the diagnostics signals are partly inferred from the Smartcar signal schema conventions (the extractors fall back across the likely keys, e.g. `status`/`value`, `value`/`count`/`codes`), since these signals aren't available on my plan/vehicle to capture real payloads. Review welcome there — happy to adjust once someone can share a real webhook payload for a diagnostics-capable vehicle.

## 3. Demote structural signal errors to DEBUG

`COMPATIBILITY:VEHICLE_NOT_CAPABLE` and `VEHICLE_STATE:NOT_CHARGING` recur on **every** update for vehicles that simply don't support a signal (my SEAT Leon reports ~30 of them per refresh), flooding the log at ERROR level with permanent noise. These two conditions are now logged at DEBUG; genuine/actionable errors keep their original level.

## Testing

- Reconfigure flow and climate entities exercised live against a SEAT Leon PHEV (v3 API): scope changes round-trip correctly and the webhook URL survives reconfiguration.
- Diagnostics entities validated for setup/registration (entities are created and gated on the scope); real data pending a diagnostics-capable vehicle, see caveat above.
- Lint (`ruff check` + `ruff format` at the pinned 0.11.12) passes; no tests added yet for the new flow — can add config-flow reconfigure tests if you'd like this to land with coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
