### PR TITLE
Abort with no_vehicles when the connections list is empty

### DIFF
--- a/custom_components/smartcar/__init__.py
+++ b/custom_components/smartcar/__init__.py
@@ -381,6 +381,12 @@ async def _store_all_vehicles(
                 )
             }
 
+            # check for an empty vehicle list first: with no connections at
+            # all, the user count check below would misreport the problem as
+            # a multi-user configuration issue.
+            if not vehicle_ids:
+                raise EmptyVehicleListError
+
             if len(user_ids) != 1:
                 raise UnsupportedUserConfigurationError
 

--- a/tests/fixtures/api/list_connections_empty.json
+++ b/tests/fixtures/api/list_connections_empty.json
@@ -1,0 +1,17 @@
+{
+  "data": [],
+  "meta": {
+    "pageNumber": 1,
+    "pageSize": 0,
+    "totalCount": 0,
+    "orderBy": "createdAt",
+    "orderDirection": "DESC"
+  },
+  "links": {
+    "self": "https://vehicle.api.smartcar.com/v3/connections?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "first": "https://vehicle.api.smartcar.com/v3/connections?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "last": "https://vehicle.api.smartcar.com/v3/connections?page%5Bnumber%5D=1&page%5Bsize%5D=10",
+    "next": null,
+    "prev": null
+  }
+}

--- a/tests/snapshots/test_config_flow.ambr
+++ b/tests/snapshots/test_config_flow.ambr
@@ -370,6 +370,28 @@
   list([
   ])
 # ---
+# name: test_full_flow_v3_only[empty_connections-v3]
+  list([
+    tuple(
+      'POST',
+      URL('https://iam.smartcar.com/oauth2/token'),
+      dict({
+        'client_id': 'client_mock-id',
+        'client_secret': 'mock-secret',
+        'grant_type': 'client_credentials',
+      }),
+      None,
+    ),
+    tuple(
+      'get',
+      URL('http://test.local/v3/connections'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
 # name: test_full_flow_v3_only[invalid_user_configuration-v3]
   list([
     tuple(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -202,6 +202,20 @@ async def test_full_flow(
             },
             {
                 "form_type": FlowResultType.ABORT,
+                "abort_reason": "not_single_user_app",
+                "errors": {},
+            },
+        ),
+        (
+            {"empty_connections"},
+            {},
+            {
+                CONF_APPLICATION_ID: "my-app-id",
+                "use_webhooks": False,
+            },
+            {
+                "form_type": FlowResultType.ABORT,
+                "abort_reason": "no_vehicles",
                 "errors": {},
             },
         ),
@@ -209,6 +223,7 @@ async def test_full_flow(
     ids=[
         "missing_application_id",
         "invalid_user_configuration",
+        "empty_connections",
     ],
 )
 async def test_full_flow_v3_only(
@@ -255,6 +270,7 @@ async def _test_full_flow(
     expected_result = deepcopy(expected_result)
     final_step = expected_result.pop("final_step", None)
     expected_errors = expected_result.pop("errors", None)
+    expected_abort_reason = expected_result.pop("abort_reason", None)
     expected_placeholders = expected_result.pop("description_placeholders", None)
     expected_data = expected_result.pop("data", {})
     expected_form_type = expected_result.pop(
@@ -370,12 +386,15 @@ async def _test_full_flow(
                 OAUTH2_TOKEN,
                 json=server_access_token,
             )
+            connections_fixture = "list_connections"
+            if "multi_user_app" in setup:
+                connections_fixture = "list_connections_with_multiple_users"
+            elif "empty_connections" in setup:
+                connections_fixture = "list_connections_empty"
             aioclient_mock.get(
                 f"{MOCK_API_ENDPOINT}/connections",
                 json=load_json_object_fixture(
-                    f"api/list_connections{
-                        '_with_multiple_users' if 'multi_user_app' in setup else ''
-                    }.json",
+                    f"api/{connections_fixture}.json",
                     DOMAIN,
                 ),
             )
@@ -388,7 +407,11 @@ async def _test_full_flow(
             )
             expected_aioclient_mock_calls += (
                 3  # oauth token & 2 for connections/signals
-                - (1 if "multi_user_app" in setup else 0)
+                - (
+                    1  # the signals request is never made when the flow aborts
+                    if setup & {"multi_user_app", "empty_connections"}
+                    else 0
+                )
             )
 
         with (
@@ -422,6 +445,9 @@ async def _test_full_flow(
     if expected_errors is not None:
         assert result.get("errors", {}) == expected_errors
         assert result["description_placeholders"] == expected_placeholders
+
+        if expected_abort_reason is not None:
+            assert result["reason"] == expected_abort_reason
     else:
         entries = hass.config_entries.async_entries(DOMAIN)
         assert len(entries) == 1


### PR DESCRIPTION
## Problem

With the v3 API, an application with **no connections at all** aborts the config flow with "Application must have only a single user connected" — misleading, since the real problem is that nothing is connected: the user-count check runs before the empty-vehicle-list check. Hit this while cleaning up my dashboard connections during the #123 testing.

## Changes

- check the vehicle list first in `_store_all_vehicles` so the flow aborts with `no_vehicles` instead;
- add an `empty_connections` flow test (fixture modeled on the real empty API response) and assert the abort reasons in the full-flow tests — previously the multi-user case validated the abort without checking its reason, so this kind of regression wouldn't have been caught.

## Testing

Verified on my fork's CI (full CI doesn't run against this base branch): Pytest — 240 tests passing including the 100% coverage gate — and Lint are both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
