### PR TITLE
docs: add FAQ section for webhook payloads rejected with invalid signature

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -73,6 +73,43 @@ In your Smartcar Dashboard go to Vehicles, select your vehicle from the list, th
 
 ![log](images/FAQ3.png)
 
+### Webhook payloads rejected with `invalid signature`
+
+Your Home Assistant log fills up with this, once per webhook delivery:
+
+```
+ERROR (MainThread) [custom_components.smartcar.webhooks] ignoring message with invalid signature
+```
+
+In the Smartcar dashboard webhook log the same deliveries show a **401** response containing:
+
+```json
+{"error": {"code": "invalid_signature", "message": "invalid signature on request body"}}
+```
+
+The payloads themselves are fine. Open one in the Smartcar log and you'll see a normal `VEHICLE_STATE` event carrying the signals you subscribed to, all with a `SUCCESS` status. Home Assistant is receiving good data and discarding it, because the signature on the request body doesn't match the **Application Management Token** it has stored.
+
+**A successful webhook Verify does not rule this out.** The `VERIFY` handshake is answered before the signature check runs, so verification passes even while every data payload is being rejected.
+
+**What does not fix it:**
+
+- Regenerating the Application Management Token and re-entering it in the integration, however many times you try
+- Re-verifying the webhook, or deleting and recreating the webhook
+- Removing the integration and the Application Credentials and setting them up again
+
+Once an application is in this state, the key Smartcar signs payloads with appears to be out of step with the Application Management Token shown in the dashboard, and regenerating the token does not bring the two back into sync.
+
+**What does fix it:** delete the **application** in your Smartcar dashboard, create a new one, and set the integration up again against the new application.
+
+**If you are on the free tier**, there is a catch: the dashboard will not delete an application while it is the only one on the account, and the free plan is limited to a single application — so there is no way to do this through the UI on a free account. Two ways around it:
+
+- **Add a second application first.** This needs any paid plan. Create a second application, delete the original, then downgrade again.
+- **Create a new Smartcar account** under a different email address and set everything up there from scratch. This stays free.
+
+**After recreating the application** you will have a new Application ID, Application Management Token and API credentials, so this is a full re-setup: new Application Credentials in Home Assistant, a new webhook in the Smartcar dashboard, and re-authorizing your vehicle through Smartcar Connect.
+
+Delete the old Smartcar config entry in Home Assistant **before** adding the new one. That releases the old entity IDs, so the new entities reclaim exactly the same ones and your sensor history and automations carry over untouched. You will still need to redo the customisations that live in the entity registry: area assignments, and any sensors you had enabled that are disabled by default (the odometer is an easy one to miss).
+
 ### When all else fails: Start fresh
 
 If you’re still stuck, a clean setup often resolves lingering issues:
@@ -82,6 +119,8 @@ If you’re still stuck, a clean setup often resolves lingering issues:
 - Delete the car from your Smartcar dashboard.
 
 Then restart HA and reinstall and reconfigure everything from scratch, following the installation guide. Once finished setting it up again, it should bring your car back in HA with all its sensor history.
+
+If that still doesn't help, the last step is to delete the **application** in your Smartcar dashboard and create a new one. This is a bigger job — you get new API credentials and have to re-authorize your vehicle — and on the free tier it needs a workaround, so see [Webhook payloads rejected with `invalid signature`](#webhook-payloads-rejected-with-invalid-signature) for the details.
 
 ### Keep in mind
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -91,13 +91,13 @@ The payloads themselves are fine. Open one in the Smartcar log and you'll see a 
 
 **A successful webhook Verify does not rule this out.** The `VERIFY` handshake is answered before the signature check runs, so verification passes even while every data payload is being rejected.
 
-**What does not fix it:**
+**When the following do not resolve the issue:**
 
-- Regenerating the Application Management Token and re-entering it in the integration, however many times you try
+- Regenerating the Application Management Token and re-entering it in the integration
 - Re-verifying the webhook, or deleting and recreating the webhook
 - Removing the integration and the Application Credentials and setting them up again
 
-Once an application is in this state, the key Smartcar signs payloads with appears to be out of step with the Application Management Token shown in the dashboard, and regenerating the token does not bring the two back into sync.
+...then the application itself is likely in a state where the key Smartcar signs payloads with is out of step with the Application Management Token shown in the dashboard, and regenerating the token will not bring the two back into sync.
 
 **What does fix it:** delete the **application** in your Smartcar dashboard, create a new one, and set the integration up again against the new application.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -99,7 +99,7 @@ The payloads themselves are fine. Open one in the Smartcar log and you'll see a 
 
 ...then the application itself is likely in a state where the key Smartcar signs payloads with is out of step with the Application Management Token shown in the dashboard, and regenerating the token will not bring the two back into sync.
 
-**What does fix it:** delete the **application** in your Smartcar dashboard, create a new one, and set the integration up again against the new application.
+**The fix:** delete the **application** in your Smartcar dashboard, create a new one, and set the integration up again against the new application.
 
 **If you are on the free tier**, there is a catch: the dashboard will not delete an application while it is the only one on the account, and the free plan is limited to a single application — so there is no way to do this through the UI on a free account. Two ways around it:
 


### PR DESCRIPTION
## Summary

Adds a troubleshooting section to `FAQ.md` covering webhook data payloads that are rejected with `invalid signature` while the `VERIFY` handshake still succeeds, and documents the only fix I found: deleting the Smartcar **application** and creating a new one.

Related reports: #130 (closed as not planned) and #139.

## Why

I hit this after migrating from the legacy v2 API to v3. Every webhook delivery was rejected:

```
ERROR (MainThread) [custom_components.smartcar.webhooks] ignoring message with invalid signature
```

The payloads were healthy — a normal `VEHICLE_STATE` event, `meta.version` `4.0`, all signals `SUCCESS` — so good data was arriving and being discarded.

Two things made this hard to diagnose, and both are why I think it's worth documenting:

1. **Webhook Verify succeeds anyway.** The `VERIFY` branch answers the challenge before the signature check runs, so a green verification in the Smartcar dashboard looks like proof the Application Management Token is correct. It isn't.
2. **Regenerating the token doesn't help.** I regenerated the Application Management Token and re-entered it several times, re-verified, recreated the webhook, and removed and re-added both the integration and the Application Credentials. None of it changed anything.

What did work was deleting the application in the Smartcar dashboard and setting everything up again against a new one.

## The free-tier catch

This is the part that isn't obvious: the dashboard won't delete an application while it's the only one on the account, and the free plan is limited to a single application — so on a free account it can't be done through the UI at all. Two ways around it:

- Take a paid plan long enough to create a second application, delete the original, then downgrade.
- Create a new Smartcar account under a different email address and set up from scratch there (free).

I used the second option and webhooks have been delivering normally since.

## Changes

- New `FAQ.md` section, **Webhook payloads rejected with `invalid signature`**, placed after "Check the Smartcar log" — symptom, why a successful Verify is misleading, what doesn't fix it, what does, the free-tier workaround, and what to expect after recreating the application.
- **When all else fails: Start fresh** currently stops at deleting the credentials, the integration and the car, which reads as exhaustive. Added a pointer to the new section.

Docs only — no code changes.

## A note on the wording

I described the cause as observed behaviour rather than mechanism: *"the key Smartcar signs payloads with appears to be out of step with the Application Management Token shown in the dashboard."* I don't know what actually happens server-side, and #130 was closed without a root cause. Happy to reword if you know more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
