### PR TITLE
fix: report failed entity commands to Home Assistant

### DIFF
--- a/custom_components/smartcar/entity.py
+++ b/custom_components/smartcar/entity.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, Self
 
 from aiohttp import ClientResponseError
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.restore_state import (
     ExtraStoredData,
@@ -165,13 +166,23 @@ class SmartcarEntity[ValueT, RawValueT](
         *,
         method: str = "post",
         **kwargs,  # noqa: ARG002, ANN003
-    ) -> bool:
+    ) -> None:
         try:
-            return await async_send_command(
+            success = await async_send_command(
                 self.coordinator, subpath, payload, method=method
             )
-        except SmartcarAPIError:
-            return False
+        except SmartcarAPIError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="command_failed",
+                translation_placeholders={"status": str(err.code)},
+            ) from err
+
+        if not success:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="command_authentication_failed",
+            )
 
 
 class IndirectDescriptorDefaultType(Enum):

--- a/custom_components/smartcar/lock.py
+++ b/custom_components/smartcar/lock.py
@@ -66,9 +66,9 @@ class SmartcarDoorLock(SmartcarEntity[bool, bool], LockEntity):
             command = "/security"
             payload = {"action": "LOCK"}
 
-        if await self._async_send_command(command, payload):
-            self._inject_raw_value(value=True)
-            self.async_write_ha_state()
+        await self._async_send_command(command, payload)
+        self._inject_raw_value(value=True)
+        self.async_write_ha_state()
 
     async def async_unlock(
         self,
@@ -82,6 +82,6 @@ class SmartcarDoorLock(SmartcarEntity[bool, bool], LockEntity):
             command = "/security"
             payload = {"action": "UNLOCK"}
 
-        if await self._async_send_command(command, payload):
-            self._inject_raw_value(value=False)
-            self.async_write_ha_state()
+        await self._async_send_command(command, payload)
+        self._inject_raw_value(value=False)
+        self.async_write_ha_state()

--- a/custom_components/smartcar/number.py
+++ b/custom_components/smartcar/number.py
@@ -95,17 +95,17 @@ class SmartcarChargeLimitNumber(
             command = "/charge/limit"
             payload = {"limit": (raw_value := value / 100.0)}
 
-        if await self._async_send_command(command, payload):
-            non_global_or_conditional_limits = [
-                value
-                for value in self._extract_raw_value() or []
-                if value["type"] != "global" or value["condition"] is not None
-            ]
+        await self._async_send_command(command, payload)
+        non_global_or_conditional_limits = [
+            value
+            for value in self._extract_raw_value() or []
+            if value["type"] != "global" or value["condition"] is not None
+        ]
 
-            self._inject_raw_value(
-                [
-                    {"type": "global", "limit": raw_value, "condition": None},
-                    *non_global_or_conditional_limits,
-                ]
-            )
-            self.async_write_ha_state()
+        self._inject_raw_value(
+            [
+                {"type": "global", "limit": raw_value, "condition": None},
+                *non_global_or_conditional_limits,
+            ]
+        )
+        self.async_write_ha_state()

--- a/custom_components/smartcar/switch.py
+++ b/custom_components/smartcar/switch.py
@@ -95,9 +95,9 @@ class SmartcarChargingSwitch(SmartcarEntity[bool, bool], SwitchEntity):
             command = "/charge"
             payload = {"action": "START"}
 
-        if await self._async_send_command(command, payload):
-            self._inject_raw_value(value=True)
-            self.async_write_ha_state()
+        await self._async_send_command(command, payload)
+        self._inject_raw_value(value=True)
+        self.async_write_ha_state()
 
     async def async_turn_off(
         self,
@@ -111,9 +111,9 @@ class SmartcarChargingSwitch(SmartcarEntity[bool, bool], SwitchEntity):
             command = "/charge"
             payload = {"action": "STOP"}
 
-        if await self._async_send_command(command, payload):
-            self._inject_raw_value(value=False)
-            self.async_write_ha_state()
+        await self._async_send_command(command, payload)
+        self._inject_raw_value(value=False)
+        self.async_write_ha_state()
 
 
 class SmartcarClimateSwitch(SmartcarEntity[bool, bool], SwitchEntity):
@@ -137,9 +137,9 @@ class SmartcarClimateSwitch(SmartcarEntity[bool, bool], SwitchEntity):
             command = "/climate"
             payload = {"action": "START"}
 
-        if await self._async_send_command(command, payload):
-            self._inject_raw_value(value=True)
-            self.async_write_ha_state()
+        await self._async_send_command(command, payload)
+        self._inject_raw_value(value=True)
+        self.async_write_ha_state()
 
     async def async_turn_off(
         self,
@@ -153,6 +153,6 @@ class SmartcarClimateSwitch(SmartcarEntity[bool, bool], SwitchEntity):
             command = "/climate"
             payload = {"action": "STOP"}
 
-        if await self._async_send_command(command, payload):
-            self._inject_raw_value(value=False)
-            self.async_write_ha_state()
+        await self._async_send_command(command, payload)
+        self._inject_raw_value(value=False)
+        self.async_write_ha_state()

--- a/custom_components/smartcar/translations/en.json
+++ b/custom_components/smartcar/translations/en.json
@@ -76,6 +76,12 @@
     }
   },
   "exceptions": {
+    "command_failed": {
+      "message": "The Smartcar vehicle command failed (HTTP {status})."
+    },
+    "command_authentication_failed": {
+      "message": "The Smartcar vehicle command failed because authentication is required. Reauthenticate the Smartcar integration and try again."
+    },
     "batch_update_error": {
       "message": "An error occurred while retrieving vehicle state from the Smartcar API: {error}"
     }

--- a/tests/snapshots/test_lock.ambr
+++ b/tests/snapshots/test_lock.ambr
@@ -25,7 +25,7 @@
     ),
   ])
 # ---
-# name: test_lock[unknown_make-lock-401-unauthroized-unlocked-NoneType-1-v2]
+# name: test_lock[unknown_make-lock-401-unauthroized-unlocked-HomeAssistantError-1-v2]
   list([
     tuple(
       'post',
@@ -39,7 +39,7 @@
     ),
   ])
 # ---
-# name: test_lock[unknown_make-lock-401-unauthroized-unlocked-NoneType-1-v3]
+# name: test_lock[unknown_make-lock-401-unauthroized-unlocked-HomeAssistantError-1-v3]
   list([
     tuple(
       'post',
@@ -51,7 +51,7 @@
     ),
   ])
 # ---
-# name: test_lock[unknown_make-lock-409-unreachable-unlocked-NoneType-1-v2]
+# name: test_lock[unknown_make-lock-409-unreachable-unlocked-HomeAssistantError-1-v2]
   list([
     tuple(
       'post',
@@ -65,7 +65,7 @@
     ),
   ])
 # ---
-# name: test_lock[unknown_make-lock-409-unreachable-unlocked-NoneType-1-v3]
+# name: test_lock[unknown_make-lock-409-unreachable-unlocked-HomeAssistantError-1-v3]
   list([
     tuple(
       'post',
@@ -103,7 +103,7 @@
     ),
   ])
 # ---
-# name: test_lock[unknown_make-unlock-401-unauthroized-unlocked-NoneType-1-v2]
+# name: test_lock[unknown_make-unlock-401-unauthroized-unlocked-HomeAssistantError-1-v2]
   list([
     tuple(
       'post',
@@ -117,33 +117,7 @@
     ),
   ])
 # ---
-# name: test_lock[unknown_make-unlock-401-unauthroized-unlocked-NoneType-1-v3]
-  list([
-    tuple(
-      'post',
-      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/unlock'),
-      None,
-      dict({
-        'authorization': 'Bearer mock-token',
-      }),
-    ),
-  ])
-# ---
-# name: test_lock[unknown_make-unlock-409-unreachable-unlocked-NoneType-1-v2]
-  list([
-    tuple(
-      'post',
-      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/security'),
-      dict({
-        'action': 'UNLOCK',
-      }),
-      dict({
-        'authorization': 'Bearer mock-token',
-      }),
-    ),
-  ])
-# ---
-# name: test_lock[unknown_make-unlock-409-unreachable-unlocked-NoneType-1-v3]
+# name: test_lock[unknown_make-unlock-401-unauthroized-unlocked-HomeAssistantError-1-v3]
   list([
     tuple(
       'post',
@@ -155,7 +129,33 @@
     ),
   ])
 # ---
-# name: test_lock[unknown_make-unlock-500-server-unlocked-NoneType-4-v2]
+# name: test_lock[unknown_make-unlock-409-unreachable-unlocked-HomeAssistantError-1-v2]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/security'),
+      dict({
+        'action': 'UNLOCK',
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_lock[unknown_make-unlock-409-unreachable-unlocked-HomeAssistantError-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/security/unlock'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_lock[unknown_make-unlock-500-server-unlocked-HomeAssistantError-4-v2]
   list([
     tuple(
       'post',
@@ -199,7 +199,7 @@
     ),
   ])
 # ---
-# name: test_lock[unknown_make-unlock-500-server-unlocked-NoneType-4-v3]
+# name: test_lock[unknown_make-unlock-500-server-unlocked-HomeAssistantError-4-v3]
   list([
     tuple(
       'post',

--- a/tests/snapshots/test_number.ambr
+++ b/tests/snapshots/test_number.ambr
@@ -31,7 +31,7 @@
     ),
   ])
 # ---
-# name: test_charging_limit[unknown_make-401-unauthroized-90-80-NoneType-1-v2]
+# name: test_charging_limit[unknown_make-401-unauthroized-90-80-HomeAssistantError-1-v2]
   list([
     tuple(
       'post',
@@ -45,39 +45,7 @@
     ),
   ])
 # ---
-# name: test_charging_limit[unknown_make-401-unauthroized-90-80-NoneType-1-v3]
-  list([
-    tuple(
-      'post',
-      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/set-limit'),
-      dict({
-        'data': dict({
-          'attributes': dict({
-            'percent': 90.0,
-          }),
-        }),
-      }),
-      dict({
-        'authorization': 'Bearer mock-token',
-      }),
-    ),
-  ])
-# ---
-# name: test_charging_limit[unknown_make-409-unreachable-90-80-NoneType-1-v2]
-  list([
-    tuple(
-      'post',
-      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/charge/limit'),
-      dict({
-        'limit': 0.9,
-      }),
-      dict({
-        'authorization': 'Bearer mock-token',
-      }),
-    ),
-  ])
-# ---
-# name: test_charging_limit[unknown_make-409-unreachable-90-80-NoneType-1-v3]
+# name: test_charging_limit[unknown_make-401-unauthroized-90-80-HomeAssistantError-1-v3]
   list([
     tuple(
       'post',
@@ -95,7 +63,39 @@
     ),
   ])
 # ---
-# name: test_charging_limit[unknown_make-500-server-90-80-NoneType-4-v2]
+# name: test_charging_limit[unknown_make-409-unreachable-90-80-HomeAssistantError-1-v2]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/charge/limit'),
+      dict({
+        'limit': 0.9,
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_charging_limit[unknown_make-409-unreachable-90-80-HomeAssistantError-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/set-limit'),
+      dict({
+        'data': dict({
+          'attributes': dict({
+            'percent': 90.0,
+          }),
+        }),
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_charging_limit[unknown_make-500-server-90-80-HomeAssistantError-4-v2]
   list([
     tuple(
       'post',
@@ -139,7 +139,7 @@
     ),
   ])
 # ---
-# name: test_charging_limit[unknown_make-500-server-90-80-NoneType-4-v3]
+# name: test_charging_limit[unknown_make-500-server-90-80-HomeAssistantError-4-v3]
   list([
     tuple(
       'post',

--- a/tests/snapshots/test_switch.ambr
+++ b/tests/snapshots/test_switch.ambr
@@ -25,7 +25,7 @@
     ),
   ])
 # ---
-# name: test_switch[unknown_make-turn_off-401-unauthroized-off-NoneType-1-v2]
+# name: test_switch[unknown_make-turn_off-401-unauthroized-off-HomeAssistantError-1-v2]
   list([
     tuple(
       'post',
@@ -39,7 +39,7 @@
     ),
   ])
 # ---
-# name: test_switch[unknown_make-turn_off-401-unauthroized-off-NoneType-1-v3]
+# name: test_switch[unknown_make-turn_off-401-unauthroized-off-HomeAssistantError-1-v3]
   list([
     tuple(
       'post',
@@ -51,64 +51,8 @@
     ),
   ])
 # ---
-# name: test_switch[unknown_make-turn_off-409-unreachable-off-NoneType-1-v2]
+# name: test_switch[unknown_make-turn_off-409-unreachable-off-HomeAssistantError-1-v2]
   list([
-    tuple(
-      'post',
-      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/charge'),
-      dict({
-        'action': 'STOP',
-      }),
-      dict({
-        'authorization': 'Bearer mock-token',
-      }),
-    ),
-  ])
-# ---
-# name: test_switch[unknown_make-turn_off-409-unreachable-off-NoneType-1-v3]
-  list([
-    tuple(
-      'post',
-      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/stop'),
-      None,
-      dict({
-        'authorization': 'Bearer mock-token',
-      }),
-    ),
-  ])
-# ---
-# name: test_switch[unknown_make-turn_off-500-server-off-NoneType-4-v2]
-  list([
-    tuple(
-      'post',
-      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/charge'),
-      dict({
-        'action': 'STOP',
-      }),
-      dict({
-        'authorization': 'Bearer mock-token',
-      }),
-    ),
-    tuple(
-      'post',
-      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/charge'),
-      dict({
-        'action': 'STOP',
-      }),
-      dict({
-        'authorization': 'Bearer mock-token',
-      }),
-    ),
-    tuple(
-      'post',
-      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/charge'),
-      dict({
-        'action': 'STOP',
-      }),
-      dict({
-        'authorization': 'Bearer mock-token',
-      }),
-    ),
     tuple(
       'post',
       URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/charge'),
@@ -121,7 +65,115 @@
     ),
   ])
 # ---
-# name: test_switch[unknown_make-turn_off-500-server-off-NoneType-4-v3]
+# name: test_switch[unknown_make-turn_off-409-unreachable-off-HomeAssistantError-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/stop'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_off-429-rate_limit-off-HomeAssistantError-1-v2]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/charge'),
+      dict({
+        'action': 'STOP',
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_off-429-rate_limit-off-HomeAssistantError-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/stop'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_off-430-billing-off-HomeAssistantError-1-v2]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/charge'),
+      dict({
+        'action': 'STOP',
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_off-430-billing-off-HomeAssistantError-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/stop'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_off-500-server-off-HomeAssistantError-4-v2]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/charge'),
+      dict({
+        'action': 'STOP',
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'post',
+      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/charge'),
+      dict({
+        'action': 'STOP',
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'post',
+      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/charge'),
+      dict({
+        'action': 'STOP',
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+    tuple(
+      'post',
+      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/charge'),
+      dict({
+        'action': 'STOP',
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_off-500-server-off-HomeAssistantError-4-v3]
   list([
     tuple(
       'post',
@@ -147,6 +199,58 @@
         'authorization': 'Bearer mock-token',
       }),
     ),
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/stop'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_off-501-compatibility-off-HomeAssistantError-1-v2]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/charge'),
+      dict({
+        'action': 'STOP',
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_off-501-compatibility-off-HomeAssistantError-1-v3]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/stop'),
+      None,
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_off-502-upstream-off-HomeAssistantError-1-v2]
+  list([
+    tuple(
+      'post',
+      URL('http://test.local/v2.0/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/charge'),
+      dict({
+        'action': 'STOP',
+      }),
+      dict({
+        'authorization': 'Bearer mock-token',
+      }),
+    ),
+  ])
+# ---
+# name: test_switch[unknown_make-turn_off-502-upstream-off-HomeAssistantError-1-v3]
+  list([
     tuple(
       'post',
       URL('http://test.local/v3/vehicles/a1d50709-3502-4faa-ba43-a5c7565e6a09/commands/charge/stop'),
@@ -209,7 +313,7 @@
     ),
   ])
 # ---
-# name: test_switch[unknown_make-turn_on-401-unauthroized-off-NoneType-1-v2]
+# name: test_switch[unknown_make-turn_on-401-unauthroized-off-HomeAssistantError-1-v2]
   list([
     tuple(
       'post',
@@ -223,7 +327,7 @@
     ),
   ])
 # ---
-# name: test_switch[unknown_make-turn_on-401-unauthroized-off-NoneType-1-v3]
+# name: test_switch[unknown_make-turn_on-401-unauthroized-off-HomeAssistantError-1-v3]
   list([
     tuple(
       'post',
@@ -235,7 +339,7 @@
     ),
   ])
 # ---
-# name: test_switch[unknown_make-turn_on-409-unreachable-off-NoneType-1-v2]
+# name: test_switch[unknown_make-turn_on-409-unreachable-off-HomeAssistantError-1-v2]
   list([
     tuple(
       'post',
@@ -249,7 +353,7 @@
     ),
   ])
 # ---
-# name: test_switch[unknown_make-turn_on-409-unreachable-off-NoneType-1-v3]
+# name: test_switch[unknown_make-turn_on-409-unreachable-off-HomeAssistantError-1-v3]
   list([
     tuple(
       'post',

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockState
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
@@ -31,11 +32,18 @@ NO_ERROR = None.__class__
     [
         (SERVICE_LOCK, 200, "success", LockState.LOCKED, NO_ERROR, 1),
         (SERVICE_UNLOCK, 200, "success", LockState.UNLOCKED, NO_ERROR, 1),
-        (SERVICE_LOCK, 409, "unreachable", LockState.UNLOCKED, NO_ERROR, 1),
-        (SERVICE_UNLOCK, 409, "unreachable", LockState.UNLOCKED, NO_ERROR, 1),
-        (SERVICE_LOCK, 401, "unauthroized", LockState.UNLOCKED, NO_ERROR, 1),
-        (SERVICE_UNLOCK, 401, "unauthroized", LockState.UNLOCKED, NO_ERROR, 1),
-        (SERVICE_UNLOCK, 500, "server", LockState.UNLOCKED, NO_ERROR, 4),
+        (SERVICE_LOCK, 409, "unreachable", LockState.UNLOCKED, HomeAssistantError, 1),
+        (SERVICE_UNLOCK, 409, "unreachable", LockState.UNLOCKED, HomeAssistantError, 1),
+        (SERVICE_LOCK, 401, "unauthroized", LockState.UNLOCKED, HomeAssistantError, 1),
+        (
+            SERVICE_UNLOCK,
+            401,
+            "unauthroized",
+            LockState.UNLOCKED,
+            HomeAssistantError,
+            1,
+        ),
+        (SERVICE_UNLOCK, 500, "server", LockState.UNLOCKED, HomeAssistantError, 4),
     ],
 )
 @pytest.mark.parametrize("vehicle_fixture", ["unknown_make"])
@@ -104,6 +112,18 @@ async def test_lock(
         raised_error,
         expected_raises,  # type: ignore[arg-type]
     )
+
+    if isinstance(raised_error, HomeAssistantError) and api_status is not None:
+        assert raised_error.translation_domain == "smartcar"
+        if api_status == 401:
+            assert raised_error.translation_key == "command_authentication_failed"
+            assert any(
+                flow["context"].get("source") == "reauth"
+                for flow in hass.config_entries.flow.async_progress()
+            )
+        else:
+            assert raised_error.translation_key == "command_failed"
+            assert raised_error.translation_placeholders == {"status": str(api_status)}
 
     assert len(aioclient_mock.mock_calls) == 1 + api_calls
     assert [tuple(mock_call) for mock_call in aioclient_mock.mock_calls[1:]] == snapshot

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -10,7 +10,7 @@ from homeassistant.components.number import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant, State
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 import pytest
 from pytest_homeassistant_custom_component.common import (
@@ -45,9 +45,9 @@ NO_ERROR = None.__class__
     ),
     [
         (200, "success", 90, 90, NO_ERROR, 1),
-        (409, "unreachable", 90, 80, NO_ERROR, 1),
-        (401, "unauthroized", 90, 80, NO_ERROR, 1),
-        (500, "server", 90, 80, NO_ERROR, 4),
+        (409, "unreachable", 90, 80, HomeAssistantError, 1),
+        (401, "unauthroized", 90, 80, HomeAssistantError, 1),
+        (500, "server", 90, 80, HomeAssistantError, 4),
         (None, None, 40, 80, ServiceValidationError, 0),
         (None, None, 110, 80, ServiceValidationError, 0),
     ],
@@ -113,6 +113,18 @@ async def test_charging_limit(
         raised_error,
         expected_raises,  # type: ignore[arg-type]
     )
+
+    if isinstance(raised_error, HomeAssistantError) and api_status is not None:
+        assert raised_error.translation_domain == "smartcar"
+        if api_status == 401:
+            assert raised_error.translation_key == "command_authentication_failed"
+            assert any(
+                flow["context"].get("source") == "reauth"
+                for flow in hass.config_entries.flow.async_progress()
+            )
+        else:
+            assert raised_error.translation_key == "command_failed"
+            assert raised_error.translation_placeholders == {"status": str(api_status)}
 
     assert len(aioclient_mock.mock_calls) == 1 + api_calls
     assert [tuple(mock_call) for mock_call in aioclient_mock.mock_calls[1:]] == snapshot

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,6 +1,7 @@
 """Test switch entities."""
 
 from collections.abc import Awaitable, Callable
+from contextlib import nullcontext
 from unittest.mock import AsyncMock
 
 from aiohttp import ClientResponseError
@@ -14,6 +15,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, State
+from homeassistant.exceptions import HomeAssistantError
 import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
@@ -48,11 +50,15 @@ NO_ERROR = None.__class__
     [
         (SERVICE_TURN_ON, 200, "success", STATE_ON, NO_ERROR, 1),
         (SERVICE_TURN_OFF, 200, "success", STATE_OFF, NO_ERROR, 1),
-        (SERVICE_TURN_ON, 409, "unreachable", STATE_OFF, NO_ERROR, 1),
-        (SERVICE_TURN_OFF, 409, "unreachable", STATE_OFF, NO_ERROR, 1),
-        (SERVICE_TURN_ON, 401, "unauthroized", STATE_OFF, NO_ERROR, 1),
-        (SERVICE_TURN_OFF, 401, "unauthroized", STATE_OFF, NO_ERROR, 1),
-        (SERVICE_TURN_OFF, 500, "server", STATE_OFF, NO_ERROR, 4),
+        (SERVICE_TURN_ON, 409, "unreachable", STATE_OFF, HomeAssistantError, 1),
+        (SERVICE_TURN_OFF, 409, "unreachable", STATE_OFF, HomeAssistantError, 1),
+        (SERVICE_TURN_ON, 401, "unauthroized", STATE_OFF, HomeAssistantError, 1),
+        (SERVICE_TURN_OFF, 401, "unauthroized", STATE_OFF, HomeAssistantError, 1),
+        (SERVICE_TURN_OFF, 429, "rate_limit", STATE_OFF, HomeAssistantError, 1),
+        (SERVICE_TURN_OFF, 430, "billing", STATE_OFF, HomeAssistantError, 1),
+        (SERVICE_TURN_OFF, 500, "server", STATE_OFF, HomeAssistantError, 4),
+        (SERVICE_TURN_OFF, 501, "compatibility", STATE_OFF, HomeAssistantError, 1),
+        (SERVICE_TURN_OFF, 502, "upstream", STATE_OFF, HomeAssistantError, 1),
         (SERVICE_TURN_OFF, 503, "unavailable", STATE_OFF, ClientResponseError, 1),
     ],
 )
@@ -122,6 +128,19 @@ async def test_switch(
         raised_error,
         expected_raises,  # type: ignore[arg-type]
     )
+
+    if isinstance(raised_error, HomeAssistantError) and api_status is not None:
+        assert raised_error.translation_domain == "smartcar"
+        if api_status == 401:
+            assert raised_error.translation_key == "command_authentication_failed"
+            assert any(
+                flow["context"].get("source") == "reauth"
+                for flow in hass.config_entries.flow.async_progress()
+            )
+        else:
+            assert raised_error.translation_key == "command_failed"
+            assert raised_error.translation_placeholders == {"status": str(api_status)}
+            assert str(api_status) in str(raised_error)
 
     assert len(aioclient_mock.mock_calls) == 1 + api_calls
     assert [tuple(mock_call) for mock_call in aioclient_mock.mock_calls[1:]] == snapshot
@@ -222,12 +241,13 @@ async def test_climate_switch(
             },
         )
 
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        service_action,
-        {ATTR_ENTITY_ID: "switch.smartcar_784n_climate"},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError) if api_status != 200 else nullcontext():
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            service_action,
+            {ATTR_ENTITY_ID: "switch.smartcar_784n_climate"},
+            blocking=True,
+        )
 
     switch_state = hass.states.get("switch.smartcar_784n_climate")
     assert switch_state.state == expected_state


### PR DESCRIPTION
Entity actions currently swallow Smartcar API errors, so an unreachable vehicle or rejected command can look like a successful service call. This makes charging, climate, door-lock and charge-limit actions raise a translated HomeAssistantError when the command fails. Entity state is updated only after success.

Closes #143. This follows up on #67, which fixed error propagation for the separate smartcar.lock_doors/unlock_doors actions while retaining the entity wrapper's silent failure behavior.

- Known Smartcar errors expose the HTTP status, without including raw API response text in the user-facing message.
- HTTP 401 still starts the existing reauthentication flow and now also reports the failed entity action.
- The shared request helper, retry policy and separate smartcar domain actions retain their existing behavior.

This is an intentional behavior change for automations: failed entity actions now follow Home Assistant's normal error handling instead of allowing the automation to continue as though the command succeeded. Automations that intentionally tolerate failure can use continue_on_error.

Validation: all 248 tests and 1,368 snapshots pass with pinned dependencies on Python 3.13; 100% line and branch coverage; all applicable pre-commit hooks pass. Tests cover v2/v3 success, unreachable vehicles, authentication, rate limits, billing, server, compatibility and upstream failures, unchanged entity state on failure, and reauthentication. Existing regression expectations fail against the original implementation. Vehicle requests are simulated; this does not establish any particular manufacturer's climate support.
