### PR TITLE
fix: preserve timestamps from v3 signal polling

### DIFF
--- a/custom_components/smartcar/coordinator.py
+++ b/custom_components/smartcar/coordinator.py
@@ -830,7 +830,16 @@ class SmartcarVehicleCoordinator(DataUpdateCoordinator):
         """
         with self.create_updated_data() as (add, updated_data):
             for signal in signal_data.get("data", []):
-                add.from_signal_attributes(signal.get("attributes", {}))
+                attributes = signal.get("attributes", {})
+                add.from_signal_attributes(
+                    {
+                        **attributes,
+                        "meta": {
+                            **attributes.get("meta", {}),
+                            **signal.get("meta", {}),
+                        },
+                    }
+                )
 
             _LOGGER.debug("Coordinator %s: Signal polling update processed", self.name)
 
@@ -889,10 +898,8 @@ class _DataAdder:
                 else None
             )
 
-            if data_age:
-                data_age = dt_util.utc_from_timestamp(data_age / 1000)
-            if fetched_at:
-                fetched_at = dt_util.utc_from_timestamp(fetched_at / 1000)
+            data_age = _parse_signal_timestamp(data_age)
+            fetched_at = _parse_signal_timestamp(fetched_at)
 
             self.from_response_body(
                 code,
@@ -1031,6 +1038,20 @@ class _DataAdder:
                 self.data[f"{storage_key}:fetched_at"] = fetched_at
             elif can_clear:
                 self.data.pop(f"{storage_key}:fetched_at", None)
+
+
+def _parse_signal_timestamp(value: str | float | None) -> dt.datetime | None:
+    """Parse ISO timestamps from polling or epoch milliseconds from webhooks.
+
+    Returns:
+        The signal timestamp, or None when unavailable or an invalid ISO string.
+    """
+    timestamp: dt.datetime | None = None
+    if isinstance(value, str):
+        timestamp = dt_util.parse_datetime(value)
+    elif value:
+        timestamp = dt_util.utc_from_timestamp(value / 1000)
+    return timestamp
 
 
 def _is_integrated(signal: dict) -> bool:

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -6010,7 +6010,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_charging_cable_plugged_in]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:55:53+00:00',
       'device_class': 'plug',
+      'fetched_at': '2026-06-30T00:03:53.743000+00:00',
       'friendly_name': 'Smartcar 784N Charging Cable Plugged In',
     }),
     'context': <ANY>,
@@ -6037,7 +6039,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'door',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Door Back Left',
       'icon': 'mdi:car-door',
     }),
@@ -6052,7 +6056,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_left_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'lock',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Door Back Left Lock',
       'icon': 'mdi:car-door-lock',
     }),
@@ -6067,7 +6073,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'door',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Door Back Right',
       'icon': 'mdi:car-door',
     }),
@@ -6082,7 +6090,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_back_right_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'lock',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Door Back Right Lock',
       'icon': 'mdi:car-door-lock',
     }),
@@ -6097,7 +6107,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'door',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Door Front Left',
       'icon': 'mdi:car-door',
     }),
@@ -6112,7 +6124,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_left_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'lock',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Door Front Left Lock',
       'icon': 'mdi:car-door-lock',
     }),
@@ -6127,7 +6141,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'door',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Door Front Right',
       'icon': 'mdi:car-door',
     }),
@@ -6142,7 +6158,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_door_front_right_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'lock',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Door Front Right Lock',
       'icon': 'mdi:car-door-lock',
     }),
@@ -6157,7 +6175,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_engine_cover]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'door',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Engine Cover',
     }),
     'context': <ANY>,
@@ -6256,7 +6276,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_rear_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'door',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Rear Trunk',
     }),
     'context': <ANY>,
@@ -6270,7 +6292,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_rear_trunk_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'lock',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Rear Trunk Lock',
     }),
     'context': <ANY>,
@@ -6326,7 +6350,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_back_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'window',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Window Back Left',
     }),
     'context': <ANY>,
@@ -6340,7 +6366,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_back_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'window',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Window Back Right',
     }),
     'context': <ANY>,
@@ -6354,7 +6382,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_front_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'window',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Window Front Left',
     }),
     'context': <ANY>,
@@ -6368,7 +6398,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][binary_sensor.smartcar_784n_window_front_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'window',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Window Front Right',
     }),
     'context': <ANY>,
@@ -6413,6 +6445,8 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][device_tracker.smartcar_784n_location]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Location',
       'gps_accuracy': 0,
       'icon': 'mdi:car',
@@ -8781,6 +8815,8 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][lock.smartcar_784n_door_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Door Lock',
       'supported_features': <LockEntityFeature: 0>,
     }),
@@ -8795,6 +8831,8 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][number.smartcar_784n_charge_limit]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:55:53+00:00',
+      'fetched_at': '2026-06-30T00:03:53.743000+00:00',
       'friendly_name': 'Smartcar 784N Charge Limit',
       'icon': 'mdi:battery-charging-80',
       'max': 100.0,
@@ -8828,7 +8866,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:55:53+00:00',
       'device_class': 'battery',
+      'fetched_at': '2026-06-30T00:03:53.743000+00:00',
       'friendly_name': 'Smartcar 784N Battery',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
@@ -8942,6 +8982,8 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:55:53+00:00',
+      'fetched_at': '2026-06-30T00:03:53.743000+00:00',
       'friendly_name': 'Smartcar 784N Charging Status',
       'icon': 'mdi:ev-station',
     }),
@@ -9203,7 +9245,9 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][sensor.smartcar_784n_odometer]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'distance',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'Smartcar 784N Odometer',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
@@ -9346,6 +9390,8 @@
 # name: test_standard_setup_with_all_entities[unknown_make-v3][switch.smartcar_784n_charging]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:55:53+00:00',
+      'fetched_at': '2026-06-30T00:03:53.743000+00:00',
       'friendly_name': 'Smartcar 784N Charging',
       'icon': 'mdi:ev-plug-type2',
     }),
@@ -12834,7 +12880,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_charging_cable_plugged_in]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:55:53+00:00',
       'device_class': 'plug',
+      'fetched_at': '2026-06-30T00:03:53.743000+00:00',
       'friendly_name': 'VW ID.4 Charging Cable Plugged In',
     }),
     'context': <ANY>,
@@ -12861,7 +12909,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'door',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Door Back Left',
       'icon': 'mdi:car-door',
     }),
@@ -12876,7 +12926,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_left_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'lock',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Door Back Left Lock',
       'icon': 'mdi:car-door-lock',
     }),
@@ -12891,7 +12943,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'door',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Door Back Right',
       'icon': 'mdi:car-door',
     }),
@@ -12906,7 +12960,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_back_right_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'lock',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Door Back Right Lock',
       'icon': 'mdi:car-door-lock',
     }),
@@ -12921,7 +12977,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'door',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Door Front Left',
       'icon': 'mdi:car-door',
     }),
@@ -12936,7 +12994,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_left_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'lock',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Door Front Left Lock',
       'icon': 'mdi:car-door-lock',
     }),
@@ -12951,7 +13011,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'door',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Door Front Right',
       'icon': 'mdi:car-door',
     }),
@@ -12966,7 +13028,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_door_front_right_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'lock',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Door Front Right Lock',
       'icon': 'mdi:car-door-lock',
     }),
@@ -12981,7 +13045,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_engine_cover]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'door',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Engine Cover',
     }),
     'context': <ANY>,
@@ -13080,7 +13146,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_trunk]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'door',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Rear Trunk',
     }),
     'context': <ANY>,
@@ -13094,7 +13162,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_rear_trunk_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'lock',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Rear Trunk Lock',
     }),
     'context': <ANY>,
@@ -13150,7 +13220,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_back_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'window',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Window Back Left',
     }),
     'context': <ANY>,
@@ -13164,7 +13236,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_back_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'window',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Window Back Right',
     }),
     'context': <ANY>,
@@ -13178,7 +13252,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_front_left]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'window',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Window Front Left',
     }),
     'context': <ANY>,
@@ -13192,7 +13268,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][binary_sensor.vw_id_4_window_front_right]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'window',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Window Front Right',
     }),
     'context': <ANY>,
@@ -13237,6 +13315,8 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][device_tracker.vw_id_4_location]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Location',
       'gps_accuracy': 0,
       'icon': 'mdi:car',
@@ -15605,6 +15685,8 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][lock.vw_id_4_door_lock]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Door Lock',
       'supported_features': <LockEntityFeature: 0>,
     }),
@@ -15619,6 +15701,8 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][number.vw_id_4_charge_limit]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:55:53+00:00',
+      'fetched_at': '2026-06-30T00:03:53.743000+00:00',
       'friendly_name': 'VW ID.4 Charge Limit',
       'icon': 'mdi:battery-charging-80',
       'max': 100.0,
@@ -15652,7 +15736,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_battery]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:55:53+00:00',
       'device_class': 'battery',
+      'fetched_at': '2026-06-30T00:03:53.743000+00:00',
       'friendly_name': 'VW ID.4 Battery',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
@@ -15766,6 +15852,8 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_charging_status]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:55:53+00:00',
+      'fetched_at': '2026-06-30T00:03:53.743000+00:00',
       'friendly_name': 'VW ID.4 Charging Status',
       'icon': 'mdi:ev-station',
     }),
@@ -16023,7 +16111,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_odometer]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:46:50.695000+00:00',
       'device_class': 'distance',
+      'fetched_at': '2026-06-30T00:03:53.557000+00:00',
       'friendly_name': 'VW ID.4 Odometer',
       'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
       'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
@@ -16039,7 +16129,9 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][sensor.vw_id_4_range]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:55:53+00:00',
       'device_class': 'distance',
+      'fetched_at': '2026-06-30T00:03:53.743000+00:00',
       'friendly_name': 'VW ID.4 Range',
       'icon': 'mdi:map-marker-distance',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
@@ -16166,6 +16258,8 @@
 # name: test_standard_setup_with_all_entities[vw_id_4-v3][switch.vw_id_4_charging]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'age': '2026-06-29T23:55:53+00:00',
+      'fetched_at': '2026-06-30T00:03:53.743000+00:00',
       'friendly_name': 'VW ID.4 Charging',
       'icon': 'mdi:ev-plug-type2',
     }),

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,100 @@
+"""Test signal timestamp handling across polling and webhooks."""
+
+import copy
+import datetime as dt
+
+from homeassistant.core import HomeAssistant
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.smartcar import coordinator as coordinator_module
+
+from . import setup_integration
+
+
+@pytest.mark.parametrize("vehicle_fixture", ["vw_id_4"])
+@pytest.mark.parametrize("client_id_version", ["v3"])
+async def test_v3_polling_preserves_signal_metadata(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    vehicle: dict,
+) -> None:
+    """Expose per-signal OEM and retrieval times from the v3 response."""
+    original_response = copy.deepcopy(vehicle["_api"])
+    await setup_integration(hass, mock_config_entry)
+    assert vehicle["_api"] == original_response
+    state = hass.states.get("sensor.vw_id_4_battery")
+    assert state is not None
+    assert state.attributes["age"] == "2026-06-29T23:55:53+00:00"
+    assert state.attributes["fetched_at"] == "2026-06-30T00:03:53.743000+00:00"
+
+
+@pytest.mark.parametrize(
+    ("timestamp", "expected"),
+    [
+        (
+            "2026-06-29T23:55:53.000Z",
+            dt.datetime(2026, 6, 29, 23, 55, 53, tzinfo=dt.UTC),
+        ),
+        (
+            "2026-06-30T01:55:53+02:00",
+            dt.datetime(2026, 6, 29, 23, 55, 53, tzinfo=dt.UTC),
+        ),
+        (1782777353000, dt.datetime(2026, 6, 29, 23, 55, 53, tzinfo=dt.UTC)),
+        (1782777353743.0, dt.datetime(2026, 6, 29, 23, 55, 53, 743000, tzinfo=dt.UTC)),
+        (0, None),
+        (None, None),
+        ("not-a-timestamp", None),
+    ],
+    ids=[
+        "iso-utc",
+        "iso-offset",
+        "milliseconds",
+        "fractional-milliseconds",
+        "zero-unavailable",
+        "missing",
+        "invalid",
+    ],
+)
+def test_signal_timestamps(timestamp, expected: dt.datetime | None) -> None:
+    """Parse both API timestamp formats without changing the payload."""
+    signal = {
+        "code": "tractionbattery-stateofcharge",
+        "body": {"value": 73, "unit": "percent"},
+        "meta": {"oemUpdatedAt": timestamp, "retrievedAt": timestamp},
+    }
+    original = copy.deepcopy(signal)
+    old_time = dt.datetime(2025, 1, 1, tzinfo=dt.UTC)
+    data: dict = {
+        "tractionbattery-stateofcharge:data_age": old_time,
+        "tractionbattery-stateofcharge:fetched_at": old_time,
+    }
+    coordinator_module._DataAdder(data).from_signal_attributes(signal)
+
+    assert data["tractionbattery-stateofcharge"] == {"value": 0.73}
+    assert data.get("tractionbattery-stateofcharge:data_age") == expected
+    assert data.get("tractionbattery-stateofcharge:fetched_at") == expected
+    assert signal == original
+
+
+def test_failed_signal_preserves_previous_timestamps() -> None:
+    """A failed signal must not replace the last successful observation time."""
+    old_time = dt.datetime(2025, 1, 1, tzinfo=dt.UTC)
+    data: dict = {
+        "tractionbattery-stateofcharge": {"value": 0.73},
+        "tractionbattery-stateofcharge:data_age": old_time,
+        "tractionbattery-stateofcharge:fetched_at": old_time,
+    }
+    coordinator_module._DataAdder(data).from_signal_attributes(
+        {
+            "code": "tractionbattery-stateofcharge",
+            "status": {"value": "ERROR"},
+            "meta": {
+                "oemUpdatedAt": "2026-06-29T23:55:53.000Z",
+                "retrievedAt": "2026-06-30T00:03:53.743Z",
+            },
+        }
+    )
+    assert data["tractionbattery-stateofcharge"] == {"value": None}
+    assert data["tractionbattery-stateofcharge:data_age"] == old_time
+    assert data["tractionbattery-stateofcharge:fetched_at"] == old_time


### PR DESCRIPTION
V3 signal polling currently passes only attributes to the signal parser, dropping the sibling meta object. Sensor values update but their age and fetched_at attributes remain missing. This forwards the per-signal metadata and parses the ISO timestamps returned by v3 polling.

Closes #142.

The parser continues to accept webhook timestamps in epoch milliseconds. Existing embedded metadata remains available, zero/missing timestamps stay unknown, failed signals retain their previous observation times, and input payloads are not mutated. Snapshot changes add the newly available timestamps to v3 entity attributes.

Validation: all 249 tests and 1,360 snapshots pass with pinned dependencies on Python 3.13; 100% line and branch coverage; all applicable pre-commit hooks pass. New tests check end-to-end v3 sensor attributes, ISO offsets, numeric timestamps, missing/invalid timestamps and failed signals. The timestamp regressions reproduce against the original implementation. Tests use the existing recorded fixtures and simulated requests.
