### PR TITLE
Fix v3 vin 404

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:system"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python-envs.defaultEnvManager": "ms-python.python:system"
-}

--- a/custom_components/smartcar/__init__.py
+++ b/custom_components/smartcar/__init__.py
@@ -433,21 +433,36 @@ async def _store_vehicle_details(
                 "get",
                 f"vehicles/{vehicle_id}/signals/vehicleidentification-vin",
             )
-            signals_resp.raise_for_status()
-            signals_data = await signals_resp.json()
-            vehicle_info = (
-                signals_data.get("included", {})
-                .get("vehicle", {})
-                .get("attributes", {})
-            )
 
-            vin = (
-                signals_data.get("data", {})
-                .get("attributes", {})
-                .get("body", {})
-                .get("value", None)
-            )
+            if signals_resp.status == HTTPStatus.NOT_FOUND:
+                _LOGGER.info(
+                    "VIN signal unavailable for vehicle %s",
+                    vehicle_id,
+                )
 
+                vin = None
+
+                vehicle_info = {}
+            else:
+                signals_resp.raise_for_status()
+
+                signals_data = await signals_resp.json()
+
+                vehicle_info = (
+                    signals_data.get("included", {})
+                    .get("vehicle", {})
+                    .get("attributes", {})
+                )
+
+                vin = (
+                    signals_data.get("data", {})
+                    .get("attributes", {})
+                    .get("body", {})
+                    .get("value", None)
+                )
+
+     
+ 
         if auth.version == "v2":
             _LOGGER.debug("Fetching attributes for vehicle ID: %s", vehicle_id)
             attr_resp = await auth.request_v2("get", f"vehicles/{vehicle_id}")

--- a/tests/fixtures/api/get_vin_signal_404.json
+++ b/tests/fixtures/api/get_vin_signal_404.json
@@ -1,0 +1,3 @@
+{
+  "error": "vin endpoint unavailable"
+}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -53,6 +53,12 @@ REDIRECT_URL = "https://example.com/auth/external/callback"
             {},
         ),
         (
+            {"missing_vin_404"},
+            {},
+            {CONF_APPLICATION_ID: "my-app-id", "use_webhooks": False},
+            {},
+),
+        (
             set(),
             {},
             {
@@ -144,6 +150,7 @@ REDIRECT_URL = "https://example.com/auth/external/callback"
         "webhooks_extraneous_token",
         "cloud_webhooks",
         "cloud_not_connected",
+        "no_webhooks_missing_vin_404",
     ],
 )
 async def test_full_flow(
@@ -342,7 +349,11 @@ async def _test_full_flow(
         assert resp.headers["content-type"] == "text/html; charset=utf-8"
 
         vehicle_id = "36ab27d0-fd9d-4455-823a-ce30af709ffc"
-        vin = "5YJSA1CN5DFP00101" if "missing_vin" not in setup else None
+        vin = (
+            "5YJSA1CN5DFP00101"
+            if not (setup & {"missing_vin", "missing_vin_404"})
+            else None
+        )
 
         if client_id_version == "v2":
             server_access_token = {
@@ -398,10 +409,23 @@ async def _test_full_flow(
                     DOMAIN,
                 ),
             )
+            vin_status = (
+                404
+                if "missing_vin_404" in setup
+                else 200
+            )
+
+            vin_fixture = (
+                "api/get_vin_signal_404.json"
+                if "missing_vin_404" in setup
+                else f"api/get_vin_signal{'_missing' if 'missing_vin' in setup else ''}.json"
+            )
+
             aioclient_mock.get(
                 f"{MOCK_API_ENDPOINT}/vehicles/{vehicle_id}/signals/vehicleidentification-vin",
+                status=vin_status,
                 json=load_json_object_fixture(
-                    f"api/get_vin_signal{'_missing' if 'missing_vin' in setup else ''}.json",
+                    vin_fixture,
                     DOMAIN,
                 ),
             )
@@ -463,7 +487,7 @@ async def _test_full_flow(
             "model": "Model S",
             "year": "2014",
         }
-        if "missing_vin" in setup:
+        if setup & {"missing_vin", "missing_vin_404"}:
             expected_attrs.pop("vin")
         assert "token" in data
         del data["token"]["expires_at"]


### PR DESCRIPTION
Some vehicles (BMW in my case) return HTTP 404 for /signals/vehicleidentification-vin rather than returning a valid signal payload with a null VIN.

This change adds test coverage for that behaviour and allows setup to continue when the VIN signal is unavailable.

I have not yet been able to run the full test suite locally due dependency issues on Windows/Python 3.13, so I'm opening this as a draft to get CI feedback.